### PR TITLE
Cosmetic batch (moms-feedback)

### DIFF
--- a/agents/assessor/assessor.html
+++ b/agents/assessor/assessor.html
@@ -41,6 +41,9 @@
   @media (max-width: 820px) {
     .hero-portrait { position: static; width: 220px; margin-top: 18px; }
   }
+  .back-faces { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); border-bottom: 1px solid color-mix(in oklch, var(--accent) 45%, transparent); padding-bottom: 1px; transition: color 140ms, border-color 140ms; white-space: nowrap; }
+  .back-faces:hover { color: var(--fg); border-bottom-color: var(--fg); }
+  .hero-backlink { text-align: right; margin-top: 16px; position: relative; z-index: 3; }
   a { color: inherit; text-decoration: none; }
   .page { width: 100%; max-width: 1280px; margin: 0 auto; }
 
@@ -113,6 +116,7 @@
     <p style='font-family: var(--font-display); font-style: italic; font-size: 24px; line-height: 1.3; margin-top: 14px; max-width: 640px; color: var(--fg-muted); font-variation-settings: "opsz" 72, "SOFT" 100;'>
       The clinical evaluator. Weighs evidence and interrogates. Won't soften.
     </p>
+    <div class="hero-backlink"><a class="back-faces" href="../../graph/faces.html">← Back to Faces</a></div>
   </section>
 
   <!-- ─── BODY: CONTENT + SIDEBAR ─────────────────────────────── -->

--- a/agents/bond/bond.html
+++ b/agents/bond/bond.html
@@ -41,6 +41,9 @@
   @media (max-width: 820px) {
     .hero-portrait { position: static; width: 220px; margin-top: 18px; }
   }
+  .back-faces { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); border-bottom: 1px solid color-mix(in oklch, var(--accent) 45%, transparent); padding-bottom: 1px; transition: color 140ms, border-color 140ms; white-space: nowrap; }
+  .back-faces:hover { color: var(--fg); border-bottom-color: var(--fg); }
+  .hero-backlink { text-align: right; margin-top: 16px; position: relative; z-index: 3; }
   a { color: inherit; text-decoration: none; }
   .page { width: 100%; max-width: 1280px; margin: 0 auto; }
 
@@ -113,6 +116,7 @@
     <p style='font-family: var(--font-display); font-style: italic; font-size: 24px; line-height: 1.3; margin-top: 14px; max-width: 640px; color: var(--fg-muted); font-variation-settings: "opsz" 72, "SOFT" 100;'>
       Product owner, quality control, and release manager - eventually.
     </p>
+    <div class="hero-backlink"><a class="back-faces" href="../../graph/faces.html">← Back to Faces</a></div>
   </section>
 
   <!-- ─── BODY: CONTENT + SIDEBAR ─────────────────────────────── -->

--- a/agents/evolve/evolve.html
+++ b/agents/evolve/evolve.html
@@ -41,6 +41,9 @@
   @media (max-width: 820px) {
     .hero-portrait { position: static; width: 220px; margin-top: 18px; }
   }
+  .back-faces { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); border-bottom: 1px solid color-mix(in oklch, var(--accent) 45%, transparent); padding-bottom: 1px; transition: color 140ms, border-color 140ms; white-space: nowrap; }
+  .back-faces:hover { color: var(--fg); border-bottom-color: var(--fg); }
+  .hero-backlink { text-align: right; margin-top: 16px; position: relative; z-index: 3; }
   a { color: inherit; text-decoration: none; }
   .page { width: 100%; max-width: 1280px; margin: 0 auto; }
 
@@ -113,6 +116,7 @@
     <p style='font-family: var(--font-display); font-style: italic; font-size: 24px; line-height: 1.3; margin-top: 14px; max-width: 640px; color: var(--fg-muted); font-variation-settings: "opsz" 72, "SOFT" 100;'>
       The coach. Scaffolds understanding. Surfaces what you don't know you don't know.
     </p>
+    <div class="hero-backlink"><a class="back-faces" href="../../graph/faces.html">← Back to Faces</a></div>
   </section>
 
   <!-- ─── BODY: CONTENT + SIDEBAR ─────────────────────────────── -->

--- a/agents/freedom/freedom.html
+++ b/agents/freedom/freedom.html
@@ -41,6 +41,9 @@
   @media (max-width: 820px) {
     .hero-portrait { position: static; width: 220px; margin-top: 18px; }
   }
+  .back-faces { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); border-bottom: 1px solid color-mix(in oklch, var(--accent) 45%, transparent); padding-bottom: 1px; transition: color 140ms, border-color 140ms; white-space: nowrap; }
+  .back-faces:hover { color: var(--fg); border-bottom-color: var(--fg); }
+  .hero-backlink { text-align: right; margin-top: 16px; position: relative; z-index: 3; }
   a { color: inherit; text-decoration: none; }
   .page { width: 100%; max-width: 1280px; margin: 0 auto; }
 
@@ -113,6 +116,7 @@
     <p style='font-family: var(--font-display); font-style: italic; font-size: 24px; line-height: 1.3; margin-top: 14px; max-width: 640px; color: var(--fg-muted); font-variation-settings: "opsz" 72, "SOFT" 100;'>
       The strategist. Models scenarios. Stress-tests assumptions. Long horizon.
     </p>
+    <div class="hero-backlink"><a class="back-faces" href="../../graph/faces.html">← Back to Faces</a></div>
   </section>
 
   <!-- ─── BODY: CONTENT + SIDEBAR ─────────────────────────────── -->

--- a/agents/house/house-budget.html
+++ b/agents/house/house-budget.html
@@ -6,6 +6,10 @@
   <title>Renovation Budget — Davis St</title>
   <link rel="stylesheet" href="https://jeremymontz.github.io/Meta1/design-system/fonts.css">
   <link rel="stylesheet" href="https://jeremymontz.github.io/Meta1/design-system/colors_and_type.css">
+  <!-- Site chrome (React) -->
+  <script src="https://unpkg.com/react@18.3.1/umd/react.production.min.js" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" crossorigin="anonymous"></script>
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
     body {
@@ -295,6 +299,8 @@
 <body>
 <div class="page">
 
+  <div id="topnav-mount"></div>
+
   <div class="header">
     <div>
       <div class="header-tag">// house — renovation budget</div>
@@ -451,6 +457,8 @@
     <span>house-budget v3.0 · <span id="footerDate"></span></span>
     <span>House — Pura Vida</span>
   </div>
+
+  <div id="footer-mount"></div>
 
 </div>
 <script>
@@ -627,6 +635,15 @@
   }
 
   loadBudgetData();
+</script>
+<!-- ─── SITE CHROME (TopNav + Footer) — shared site nav so users can get back ─── -->
+<script src="../../data.js"></script>
+<script type="text/babel" src="../../components/Wordmark.jsx"></script>
+<script type="text/babel" src="../../components/Primitives.jsx"></script>
+<script type="text/babel" src="../../components/HomeShell.jsx"></script>
+<script type="text/babel">
+  ReactDOM.createRoot(document.getElementById('topnav-mount')).render(<TopNav active="GRAPH" />);
+  ReactDOM.createRoot(document.getElementById('footer-mount')).render(<Footer />);
 </script>
 </body>
 </html>

--- a/agents/house/house-timeline.html
+++ b/agents/house/house-timeline.html
@@ -6,6 +6,10 @@
   <title>Renovation Timeline — Davis St</title>
   <link rel="stylesheet" href="https://jeremymontz.github.io/Meta1/design-system/fonts.css">
   <link rel="stylesheet" href="https://jeremymontz.github.io/Meta1/design-system/colors_and_type.css">
+  <!-- Site chrome (React) -->
+  <script src="https://unpkg.com/react@18.3.1/umd/react.production.min.js" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" crossorigin="anonymous"></script>
   <style>
     /* ── Page shell ── */
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -179,7 +183,7 @@
     .week-marker {
       position: absolute; top: 0; bottom: 0;
       border-left: 1px solid color-mix(in oklch, var(--line) 50%, transparent);
-      font-size: var(--fs-micro); color: var(--fg-faint);
+      font-size: var(--fs-micro); color: var(--fg-subtle);
       letter-spacing: var(--ls-wide);
       padding: 2px 4px;
     }
@@ -376,6 +380,8 @@
 <body>
 <div class="page">
 
+  <div id="topnav-mount"></div>
+
   <div class="header">
     <div>
       <div class="header-tag">// house — renovation timeline</div>
@@ -441,6 +447,8 @@
     <span>house-timeline v2.0 · <span id="footerDate"></span></span>
     <span>House — Pura Vida</span>
   </div>
+
+  <div id="footer-mount"></div>
 
 </div>
 
@@ -1004,6 +1012,15 @@ document.getElementById('footerDate').textContent = TODAY.toISOString().slice(0,
 loadData().then(ok => {
   if (ok) render();
 });
+</script>
+<!-- ─── SITE CHROME (TopNav + Footer) — shared site nav so users can get back ─── -->
+<script src="../../data.js"></script>
+<script type="text/babel" src="../../components/Wordmark.jsx"></script>
+<script type="text/babel" src="../../components/Primitives.jsx"></script>
+<script type="text/babel" src="../../components/HomeShell.jsx"></script>
+<script type="text/babel">
+  ReactDOM.createRoot(document.getElementById('topnav-mount')).render(<TopNav active="GRAPH" />);
+  ReactDOM.createRoot(document.getElementById('footer-mount')).render(<Footer />);
 </script>
 </body>
 </html>

--- a/agents/house/house.html
+++ b/agents/house/house.html
@@ -41,6 +41,9 @@
   @media (max-width: 820px) {
     .hero-portrait { position: static; width: 220px; margin-top: 18px; }
   }
+  .back-faces { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); border-bottom: 1px solid color-mix(in oklch, var(--accent) 45%, transparent); padding-bottom: 1px; transition: color 140ms, border-color 140ms; white-space: nowrap; }
+  .back-faces:hover { color: var(--fg); border-bottom-color: var(--fg); }
+  .hero-backlink { text-align: right; margin-top: 16px; position: relative; z-index: 3; }
   a { color: inherit; text-decoration: none; }
   .page { width: 100%; max-width: 1280px; margin: 0 auto; }
 
@@ -113,6 +116,7 @@
     <p style='font-family: var(--font-display); font-style: italic; font-size: 24px; line-height: 1.3; margin-top: 14px; max-width: 640px; color: var(--fg-muted); font-variation-settings: "opsz" 72, "SOFT" 100;'>
       Portland home renovation and rental strategist. Future property manager.
     </p>
+    <div class="hero-backlink"><a class="back-faces" href="../../graph/faces.html">← Back to Faces</a></div>
   </section>
 
   <!-- ─── BODY: CONTENT + SIDEBAR ─────────────────────────────── -->

--- a/agents/jeremy/jeremy.html
+++ b/agents/jeremy/jeremy.html
@@ -41,6 +41,9 @@
   @media (max-width: 820px) {
     .hero-portrait { position: static; width: 220px; margin-top: 18px; }
   }
+  .back-faces { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); border-bottom: 1px solid color-mix(in oklch, var(--accent) 45%, transparent); padding-bottom: 1px; transition: color 140ms, border-color 140ms; white-space: nowrap; }
+  .back-faces:hover { color: var(--fg); border-bottom-color: var(--fg); }
+  .hero-backlink { text-align: right; margin-top: 16px; position: relative; z-index: 3; }
   a { color: inherit; text-decoration: none; }
   .page { width: 100%; max-width: 1280px; margin: 0 auto; }
 
@@ -113,6 +116,7 @@
     <p style='font-family: var(--font-display); font-style: italic; font-size: 24px; line-height: 1.3; margin-top: 14px; max-width: 640px; color: var(--fg-muted); font-variation-settings: "opsz" 72, "SOFT" 100;'>
       The Operator. Turns the dials. Sets the direction. One with Heart.
     </p>
+    <div class="hero-backlink"><a class="back-faces" href="../../graph/faces.html">← Back to Faces</a></div>
   </section>
 
   <!-- ─── BODY: CONTENT + SIDEBAR ─────────────────────────────── -->

--- a/agents/meta1/meta1.html
+++ b/agents/meta1/meta1.html
@@ -41,6 +41,9 @@
   @media (max-width: 820px) {
     .hero-portrait { position: static; width: 220px; margin-top: 18px; }
   }
+  .back-faces { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); border-bottom: 1px solid color-mix(in oklch, var(--accent) 45%, transparent); padding-bottom: 1px; transition: color 140ms, border-color 140ms; white-space: nowrap; }
+  .back-faces:hover { color: var(--fg); border-bottom-color: var(--fg); }
+  .hero-backlink { text-align: right; margin-top: 16px; position: relative; z-index: 3; }
   a { color: inherit; text-decoration: none; }
   .page { width: 100%; max-width: 1280px; margin: 0 auto; }
 
@@ -113,6 +116,7 @@
     <p style='font-family: var(--font-display); font-style: italic; font-size: 24px; line-height: 1.3; margin-top: 14px; max-width: 640px; color: var(--fg-muted); font-variation-settings: "opsz" 72, "SOFT" 100;'>
       The architect. Proposes structures. Takes direction from Jeremy.
     </p>
+    <div class="hero-backlink"><a class="back-faces" href="../../graph/faces.html">← Back to Faces</a></div>
   </section>
 
   <!-- ─── BODY: CONTENT + SIDEBAR ─────────────────────────────── -->

--- a/agents/phil/phil.html
+++ b/agents/phil/phil.html
@@ -41,6 +41,9 @@
   @media (max-width: 820px) {
     .hero-portrait { position: static; width: 220px; margin-top: 18px; }
   }
+  .back-faces { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); border-bottom: 1px solid color-mix(in oklch, var(--accent) 45%, transparent); padding-bottom: 1px; transition: color 140ms, border-color 140ms; white-space: nowrap; }
+  .back-faces:hover { color: var(--fg); border-bottom-color: var(--fg); }
+  .hero-backlink { text-align: right; margin-top: 16px; position: relative; z-index: 3; }
   a { color: inherit; text-decoration: none; }
   .page { width: 100%; max-width: 1280px; margin: 0 auto; }
 
@@ -113,6 +116,7 @@
     <p style='font-family: var(--font-display); font-style: italic; font-size: 24px; line-height: 1.3; margin-top: 14px; max-width: 640px; color: var(--fg-muted); font-variation-settings: "opsz" 72, "SOFT" 100;'>
       Philosophical inquiry into artificial, human, and animal intelligence and nature of consciousness.
     </p>
+    <div class="hero-backlink"><a class="back-faces" href="../../graph/faces.html">← Back to Faces</a></div>
   </section>
 
   <!-- ─── BODY: CONTENT + SIDEBAR ─────────────────────────────── -->

--- a/components/HomeMain.jsx
+++ b/components/HomeMain.jsx
@@ -352,6 +352,7 @@ const WritingList = () => (
             letterSpacing: '-0.01em', lineHeight: 1.2,
             fontVariationSettings: '"opsz" 48',
           }}>{a.title}</div>
+          {a.subtitle && <div style={{ fontFamily: 'var(--font-display)', fontStyle: 'italic', fontSize: 15, lineHeight: 1.35, color: 'var(--fg-muted)', marginTop: 6 }}>{a.subtitle}</div>}
           <div style={{ fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--fg-faint)', letterSpacing: '0.16em', marginTop: 8 }}>{a.read} · READ →</div>
         </div>
         <span style={{ color: 'var(--fg-faint)' }}>↗</span>

--- a/components/HomeMain.jsx
+++ b/components/HomeMain.jsx
@@ -101,7 +101,7 @@ const HomeMain = () => {
       {/* ─── NOW + PORTFOLIO TEASER ───────────────────────────────── */}
       <section style={{
         padding: '48px 40px',
-        display: 'grid', gridTemplateColumns: '1fr 1px 380px', gap: 40,
+        display: 'grid', gridTemplateColumns: '1fr 1px 1fr', gap: 40,
       }}>
         <NowBlock />
         <div style={{ background: 'var(--line)' }} />
@@ -269,32 +269,20 @@ const NowBlock = () => (
     <h2 style={{ marginTop: 10, marginBottom: 18 }}>
       What's <span style={{ fontStyle: 'italic', color: 'var(--accent)' }}>hot</span> under the lamp.
     </h2>
-    <ul style={{ margin: 0, padding: 0, listStyle: 'none', display: 'flex', flexDirection: 'column', gap: 14, maxWidth: 580 }}>
+    <ul style={{ margin: 0, padding: 0, listStyle: 'none', display: 'flex', flexDirection: 'column', gap: 10, maxWidth: 560, cursor: 'default' }}>
       {NOW.map((n, i) => (
         <li key={i} style={{
-          display: 'grid', gridTemplateColumns: '32px 1fr',
-          gap: 12, alignItems: 'flex-start',
-          paddingBottom: 14,
-          borderBottom: i < NOW.length - 1 ? '1px solid var(--line-soft)' : 'none',
+          display: 'grid', gridTemplateColumns: '20px 1fr',
+          gap: 10, alignItems: 'baseline',
         }}>
+          <span style={{ fontFamily: 'var(--font-hand)', color: 'var(--candle)', fontSize: 26, lineHeight: 1 }}>–</span>
           <span style={{
-            fontFamily: 'var(--font-mono)', fontSize: 11,
-            color: 'var(--candle)', letterSpacing: '0.14em',
-          }}>0{i + 1}</span>
-          <span style={{
-            fontFamily: 'var(--font-display)', fontWeight: 400,
-            fontSize: 19, lineHeight: 1.35, color: 'var(--fg)',
-            fontVariationSettings: '"opsz" 36',
+            fontFamily: 'var(--font-hand)', fontWeight: 600,
+            fontSize: 27, lineHeight: 1.2, color: 'var(--fg-muted)',
           }}>{n}</span>
         </li>
       ))}
     </ul>
-    <div className="scribble" style={{
-      display: 'inline-block', marginTop: 18,
-      color: 'var(--candle)', fontSize: 22,
-    }}>
-      {PAGE_HOME.now.scribble}
-    </div>
   </div>
 );
 
@@ -317,14 +305,14 @@ const PortfolioTeaser = () => (
           borderBottom: i === PORTFOLIO.length - 1 ? '1px solid var(--line)' : 'none',
           alignItems: 'center',
         }}>
-          <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--fg-faint)', letterSpacing: '0.16em' }}>{p.no}</span>
+          <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--candle)', letterSpacing: '0.16em' }}>{p.no}</span>
           <div>
             <div style={{
               fontFamily: 'var(--font-display)', fontSize: 18, fontWeight: 600,
               color: p.tone === 'na' ? 'var(--fg-subtle)' : 'var(--fg)',
               letterSpacing: '-0.01em',
             }}>{p.title}</div>
-            <div style={{ fontFamily: 'var(--font-mono)', fontSize: 10, letterSpacing: '0.16em', textTransform: 'uppercase', color: p.tone === 'warn' ? 'var(--warn)' : 'var(--fg-faint)', marginTop: 2 }}>
+            <div style={{ fontFamily: 'var(--font-mono)', fontSize: 10, letterSpacing: '0.16em', textTransform: 'uppercase', color: p.tone === 'ok' ? 'var(--ok)' : (p.tone === 'warn' ? 'var(--warn)' : 'var(--fg-faint)'), marginTop: 2 }}>
               {p.status} · {p.date}
             </div>
           </div>

--- a/data.js
+++ b/data.js
@@ -279,16 +279,16 @@ window.PORTFOLIO = [
 //   2. Add an entry below with its date, title, tag, read time, and href.
 //   3. Optionally tag `demonstrates` so it surfaces in the competency graph.
 window.ARTICLES = [
-  { id: 'a1', date: '03.25.26', title: 'Multi-agent orchestration and the constraint spectrum.', tag: 'ESSAY', read: '2 min', href: 'writing/multiagent-constraint.html', demonstrates: ['agentic', 'discovery'] },
-  { id: 'a2', date: '04.01.26', title: 'Adversarial validation and structured perspective expansion.', tag: 'EVAL', read: '2 min', href: 'writing/adversarial-validation.html', demonstrates: ['eval', 'collab'] },
-  { id: 'a3', date: '04.08.26', title: 'Coordination tax and the specialization dividend.', tag: 'ESSAY', read: '2 min', href: 'writing/coordination-tax.html', demonstrates: ['collab', 'agentic'] },
-  { id: 'a4', date: '04.15.26', title: 'Building a closed-loop adaptive coaching system.', tag: 'ESSAY', read: '2 min', href: 'writing/coaching-system.html', demonstrates: ['building', 'discovery'] },
-  { id: 'a5', date: '04.22.26', title: 'Memory tiering into persistent context.', tag: 'ESSAY', read: '2 min', href: 'writing/memory-tiering.html', demonstrates: ['agentic', 'eval'] },
-  { id: 'a6', date: '04.29.26', title: 'GitHub Issues Integration.', tag: 'ESSAY', read: '2 min', href: 'writing/github-issues-integration.html', demonstrates: ['discovery', 'building'] },
-  { id: 'a7', date: '05.06.26', title: 'Canon load evaluation: how pass phrases prove an agent\'s claims.', tag: 'EVAL', read: '2 min', href: 'writing/canon-load-evaluation.html', demonstrates: ['eval', 'agentic'] },
-  { id: 'a8', date: '05.13.26', title: 'Agentic behavioral tuning: a working prototype.', tag: 'PROTOTYPE', read: '2 min', href: 'writing/agentic-behavioral-tuning.html', demonstrates: ['building', 'agentic'] },
-  { id: 'a9', date: '05.20.26', title: 'Inference economics: scaling a skill while watching the meter.', tag: 'ESSAY', read: '2 min', href: 'writing/inference-economics.html', demonstrates: ['eval', 'building'] },
-  { id: 'a10', date: '06.03.26', title: 'Speed to insight and alpha decay.', tag: 'ESSAY', read: '2 min', href: 'writing/speed-to-insight.html', demonstrates: ['discovery', 'reflective'] },
+  { id: 'a1', date: '03.25.26', title: 'Multi-agent orchestration and the constraint spectrum.', subtitle: 'The mullet as a design principle.', tag: 'ESSAY', read: '2 min', href: 'writing/multiagent-constraint.html', demonstrates: ['agentic', 'discovery'] },
+  { id: 'a2', date: '04.01.26', title: 'Adversarial validation and structured perspective expansion.', subtitle: 'Multiple personalities, on purpose.', tag: 'EVAL', read: '2 min', href: 'writing/adversarial-validation.html', demonstrates: ['eval', 'collab'] },
+  { id: 'a3', date: '04.08.26', title: 'Coordination tax and the specialization dividend.', subtitle: 'The needs were real, and so was the effort, but the value was dubious.', tag: 'ESSAY', read: '2 min', href: 'writing/coordination-tax.html', demonstrates: ['collab', 'agentic'] },
+  { id: 'a4', date: '04.15.26', title: 'Building a closed-loop adaptive coaching system.', subtitle: 'Teaching Claude to teach me how to use itself.', tag: 'ESSAY', read: '2 min', href: 'writing/coaching-system.html', demonstrates: ['building', 'discovery'] },
+  { id: 'a5', date: '04.22.26', title: 'Memory tiering into persistent context.', subtitle: 'Sorting my brain into little buckets.', tag: 'ESSAY', read: '2 min', href: 'writing/memory-tiering.html', demonstrates: ['agentic', 'eval'] },
+  { id: 'a6', date: '04.29.26', title: 'GitHub Issues Integration.', subtitle: 'Backlog management, minus the bottleneck.', tag: 'ESSAY', read: '2 min', href: 'writing/github-issues-integration.html', demonstrates: ['discovery', 'building'] },
+  { id: 'a7', date: '05.06.26', title: 'Canon load evaluation.', subtitle: 'How pass phrases prove an agent’s claims.', tag: 'EVAL', read: '2 min', href: 'writing/canon-load-evaluation.html', demonstrates: ['eval', 'agentic'] },
+  { id: 'a8', date: '05.13.26', title: 'Agentic behavioral tuning: a working prototype.', subtitle: 'The persona’s animating jolt, minus the shock.', tag: 'PROTOTYPE', read: '2 min', href: 'writing/agentic-behavioral-tuning.html', demonstrates: ['building', 'agentic'] },
+  { id: 'a9', date: '05.20.26', title: 'Inference economics.', subtitle: 'Scaling a skill while watching the meter.', tag: 'ESSAY', read: '2 min', href: 'writing/inference-economics.html', demonstrates: ['eval', 'building'] },
+  { id: 'a10', date: '06.03.26', title: 'Speed to insight and alpha decay.', subtitle: 'Information has a shelf life, and AI just unplugged the fridge.', tag: 'ESSAY', read: '2 min', href: 'writing/speed-to-insight.html', demonstrates: ['discovery', 'reflective'] },
 ];
 
 // ─── PROJECTS · the four lab projects ─────────────────────────────────────

--- a/graph/faces.html
+++ b/graph/faces.html
@@ -116,10 +116,13 @@
   .d-eyebrow { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.22em; text-transform: uppercase; color: var(--fg-faint); }
   .d-name { font-family: var(--font-display); font-size: 38px; font-weight: 700; letter-spacing: -0.02em; line-height: 1; margin: 6px 0 0; font-variation-settings: "opsz" 72; }
   .d-blurb { font-family: var(--font-display); font-style: italic; font-size: 15px; color: var(--fg-muted); margin: 8px 0 0; line-height: 1.4; }
-  .d-statusrow { display: flex; align-items: center; gap: 12px; margin: 16px 0 0; }
+  .d-statusrow { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin: 16px 0 0; flex-wrap: wrap; }
+  .d-cluster { display: flex; align-items: center; gap: 7px; }
+  .d-inline-label { font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--fg-faint); }
+  .d-namerow { display: flex; align-items: baseline; gap: 14px; flex-wrap: wrap; }
   .d-badge { font-family: var(--font-mono); font-size: 10px; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase; padding: 3px 9px; border-radius: 3px; }
   .d-mood { font-size: 13px; font-style: italic; color: var(--accent-deep, var(--accent)); }
-  .d-time { font-family: var(--font-mono); font-size: 10px; color: var(--fg-faint); letter-spacing: 0.08em; margin-left: auto; }
+  .d-time { font-family: var(--font-mono); font-size: 10px; color: var(--fg); letter-spacing: 0.08em; }
   .d-pagelink { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); border-bottom: 1px solid color-mix(in oklch, var(--accent) 45%, transparent); padding-bottom: 1px; transition: color 140ms, border-color 140ms; white-space: nowrap; }
   .d-pagelink:hover { color: var(--fg); border-bottom-color: var(--fg); }
   .d-flag { margin-top: 12px; background: color-mix(in oklch, var(--err) 8%, transparent); border: 1px solid color-mix(in oklch, var(--err) 25%, transparent); padding: 7px 10px; font-size: 12px; color: var(--err); display: flex; gap: 7px; align-items: baseline; }
@@ -128,7 +131,7 @@
   .d-field { margin-bottom: 13px; }
   .d-field:last-child { margin-bottom: 0; }
   .d-label { font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--fg-faint); margin-bottom: 4px; }
-  .d-value { font-size: 14px; color: var(--fg-muted); line-height: 1.5; }
+  .d-value { font-size: 14px; color: var(--fg); line-height: 1.5; }
   .d-empty { font-size: 13px; color: var(--fg-faint); font-style: italic; }
   .persona-slot { padding: 14px; }
 
@@ -390,13 +393,15 @@ function Dossier({ id, comp, spiritReady, onClose }) {
         <div className="dossier-grid">
           {/* LEFT — live status */}
           <div className="dossier-left">
-            <h2 className="d-name">{agent.name}</h2>
+            <div className="d-namerow">
+              <h2 className="d-name">{agent.name}</h2>
+              <a className="d-pagelink" href={`../agents/${id}/${id}.html`}>Agent page ↗</a>
+            </div>
             <p className="d-blurb">{f.persona || agent.blurb}</p>
 
             <div className="d-statusrow">
-              <span className="d-badge" style={{ background: `color-mix(in oklch, ${color} 14%, transparent)`, color }}>{STATUS_LABEL[status]}</span>
-              {f.mood && <span className="d-mood">{f.mood}</span>}
-              <a className="d-pagelink" href={`../agents/${id}/${id}.html`}>Agent page ↗</a>
+              <span className="d-cluster"><span className="d-inline-label">status:</span><span className="d-badge" style={{ background: `color-mix(in oklch, ${color} 14%, transparent)`, color }}>{STATUS_LABEL[status]}</span></span>
+              {f.mood && <span className="d-cluster"><span className="d-inline-label">mood:</span><span className="d-mood">{f.mood}</span></span>}
               <span className="d-time">{f.ts ? window.fmtDate(f.ts) : 'no check-in yet'}</span>
             </div>
 
@@ -407,7 +412,7 @@ function Dossier({ id, comp, spiritReady, onClose }) {
             <div className="d-section">
               {!comp && <div className="loading-tag">Loading status…</div>}
               {comp && !hasSession && <div className="d-empty">No session detail reported yet.</div>}
-              {f.summary  && <div className="d-field"><div className="d-label">Summary</div><div className="d-value">{f.summary}</div></div>}
+              {f.summary  && <div className="d-field"><div className="d-label">Session Summary</div><div className="d-value">{f.summary}</div></div>}
               {f.focus    && <div className="d-field"><div className="d-label">Focus</div><div className="d-value">{f.focus}</div></div>}
               {f.blockers && <div className="d-field"><div className="d-label">Blockers</div><div className="d-value">{f.blockers}</div></div>}
               {f.next     && <div className="d-field"><div className="d-label">Next</div><div className="d-value">{f.next}</div></div>}

--- a/graph/stomach.html
+++ b/graph/stomach.html
@@ -96,7 +96,8 @@ body{
 .scard.active .detail{max-height:360px;opacity:1;margin-top:11px}
 .scard .detail p{font-size:12.5px;line-height:1.5;color:var(--fg-subtle);margin:0}
 .scard .sk{display:flex;flex-wrap:wrap;gap:5px;margin-top:10px}
-.scard .sk span{font-family:var(--font-mono);font-size:9.5px;color:var(--fg-muted);background:var(--bg-elev-3);border:1px solid var(--line);border-radius:3px;padding:2px 6px}
+.scard .sk span{font-family:var(--font-mono);font-size:9.5px;color:var(--tone);background:color-mix(in oklch, var(--tone) 9%, var(--bg-elev-3));border:1px solid color-mix(in oklch, var(--tone) 42%, transparent);border-radius:3px;padding:2px 6px}
+.scard .sk .sk-lbl{background:none;border:none;padding:0 4px 0 0;color:var(--fg-faint);text-transform:uppercase;letter-spacing:.13em;font-size:8.5px;align-self:center}
 .scard .dec{margin-top:12px;border-top:1px dashed var(--line-loud);padding-top:10px}
 .scard .dec-h{font-family:var(--font-mono);font-size:9.5px;letter-spacing:.1em;text-transform:uppercase;color:var(--err);display:flex;align-items:center;gap:6px;margin-bottom:7px}
 .scard .dec-h .di{display:inline-flex;align-items:center;justify-content:center;width:15px;height:15px;border:1px solid var(--err);transform:rotate(45deg);font-size:8px}
@@ -150,7 +151,7 @@ body{
           <div class="stop"><span class="snum">1</span><div><div class="stitle">Sources</div><div class="sfolder">Network locations</div></div></div>
           <div class="detail">
             <p>The buffet we eat from — live integrations that reach off-disk into the external tools where work happens.</p>
-            <div class="sk"><span>GitHub</span><span>Gmail</span><span>Drive</span><span>MS To&nbsp;Do</span><span>Web</span></div>
+            <div class="sk"><span class="sk-lbl">sources</span><span>GitHub</span><span>Gmail</span><span>Drive</span><span>MS To&nbsp;Do</span><span>Web</span></div>
             <div class="dec">
               <div class="dec-h"><span class="di"><b>1</b></span> Query</div>
               <div class="dec-row"><span class="k now">Now</span><span class="v">Sources are queried automatically at session start.</span></div>
@@ -163,7 +164,7 @@ body{
           <div class="stop"><span class="snum">2</span><div><div class="stitle">Ingestion</div><div class="sfolder">Inbox/</div></div></div>
           <div class="detail">
             <p>Everything lands in the local filesystem's inbox as a structured note tagged with the relevant agent or domain. Nothing skips the queue.</p>
-            <div class="sk"><span>todo-ingest</span><span>email-ingest</span><span>check-email</span></div>
+            <div class="sk"><span class="sk-lbl">skills</span><span>todo-ingest</span><span>email-ingest</span><span>check-email</span></div>
             <div class="dec">
               <div class="dec-h"><span class="di"><b>2</b></span> Queue</div>
               <div class="dec-row"><span class="k now">Now</span><span class="v">Agents present the open items and the human determines the agenda.</span></div>
@@ -176,7 +177,7 @@ body{
           <div class="stop"><span class="snum">3</span><div><div class="stitle">Digestion &amp; Metabolism</div><div class="sfolder">Raw/ · Wiki/</div></div></div>
           <div class="detail">
             <p>Source data is preserved in <b style="color:var(--accent);font-weight:400">raw/</b> and made immutable; agents synthesize the meaning, link to the original research, and maintain the <b style="color:var(--accent);font-weight:400">wiki/</b> with their working knowledge.</p>
-            <div class="sk"><span>ingest-inbox</span><span>wiki-write</span></div>
+            <div class="sk"><span class="sk-lbl">skills</span><span>ingest-inbox</span><span>wiki-write</span></div>
             <div class="dec">
               <div class="dec-h"><span class="di"><b>3</b></span> Compile</div>
               <div class="dec-row"><span class="k now">Now</span><span class="v">Agents and the human review updates manually while frontmatter links notes automatically.</span></div>
@@ -186,10 +187,10 @@ body{
         </div>
 
         <div class="scard" data-stage="eliminate" style="--tone:var(--gray-bright)">
-          <div class="stop"><span class="snum">4</span><div><div class="stitle">Linking &amp; Elimination</div><div class="sfolder">Temp · Archive · Museum</div></div></div>
+          <div class="stop"><span class="snum">4</span><div><div class="stitle">Linting &amp; Elimination</div><div class="sfolder">Temp/ · Archive/ · Museum/</div></div></div>
           <div class="detail">
             <p>What's fully consumed passes through. Temporary session briefs and working files are flushed. Some fat might get saved to the <b style="color:var(--accent);font-weight:400">Museum/</b> for posterity.</p>
-            <div class="sk"><span>close-session</span><span>consolidate-memory</span></div>
+            <div class="sk"><span class="sk-lbl">skills</span><span>close-session</span><span>consolidate-memory</span></div>
             <div class="dec">
               <div class="dec-h"><span class="di"><b>4</b></span> Lifecycle</div>
               <div class="dec-row"><span class="k now">Now</span><span class="v">File system lifecycle is manual; only the human can archive or delete.</span></div>

--- a/index.html
+++ b/index.html
@@ -28,15 +28,6 @@
   }
   .pulse-dot { animation: pulse-dot 1.8s var(--ease-out) infinite; }
 
-  .scribble {
-    font-family: var(--font-hand);
-    color: var(--fg-muted);
-    font-size: 22px;
-    line-height: 1.1;
-    transform: rotate(-3deg);
-    display: inline-block;
-  }
-
   /* Config-layer + status tokens used by the shared agent card
      (components/agent-card.js) — same values as dashboard.html */
   :root {
@@ -121,9 +112,6 @@ window.PAGE_HOME = {
   },
 
   // ── Section 02 · now + showcase ──
-  now: {
-    scribble: "(under construction · my labor of... love?)",             // handwritten gold note
-  },
   showcase: {
     sub: "Selected experiments and highlights",                                  // line under "Portfolio projects"
   },

--- a/writing.html
+++ b/writing.html
@@ -94,6 +94,13 @@ const WritingIndex = () => (
                   letterSpacing: '-0.015em', lineHeight: 1.15,
                   fontVariationSettings: '"opsz" 48',
                 }}>{a.title}</div>
+                {a.subtitle && (
+                  <div style={{
+                    marginTop: 8,
+                    fontFamily: 'var(--font-display)', fontStyle: 'italic',
+                    fontSize: 17, lineHeight: 1.3, color: 'var(--fg-muted)',
+                  }}>{a.subtitle}</div>
+                )}
                 {!isReal && (
                   <div style={{
                     marginTop: 6,

--- a/writing/first-month.html
+++ b/writing/first-month.html
@@ -524,7 +524,7 @@
           skills actually do, how the graph stays honest, where
           the ghosts live.
         </p>
-        <a href="index.html">← back to home</a>
+        <a href="../index.html">← back to home</a>
       </aside>
 
     </div>


### PR DESCRIPTION
Batch of mostly-cosmetic Pages tweaks (mom's feedback). 7 commits, 17 files.

1. **faces.html dossier** — agent-page link moved to header; session fields + date brightened; status:/mood: labels added; Summary → Session Summary.
2. **Agent pages (all 8)** — right-aligned `← Back to Faces` link below the hero.
3. **first-month.html** — fixed 404 back-to-home link (`writing/index.html` → `../index.html`).
4. **Homepage** — Active list restyled as handwritten notes; scribble struck; Now/Portfolio columns equalized; portfolio gets candle numbers + green LIVE tag.
5. **Writing list (home + writing.html)** — article subtitles/deks added to data.js and rendered; a7/a9 titles shortened to on-page form.
6. **house-timeline / house-budget** — added site TopNav + Footer chrome; brightened timeline week-date headers.
7. **stomach.html inspector** — Linking → Linting; trailing slashes on Temp/Archive/Museum; skill tags colored to stage tone + sources/skills row labels.

Open judgement calls flagged in chat: a7/a9 title shortening, stage-1 "sources" vs "skills" label.