### PR TITLE
Heart redesign (lectio page)

### DIFF
--- a/graph/heart-app.jsx
+++ b/graph/heart-app.jsx
@@ -36,49 +36,61 @@ const Room = () => (
 );
 
 // ── Eyebrow ─────────────────────────────────────────────────────────────
+const HeartGlyph = () => (
+  <svg viewBox="0 0 64 64" style={{ width: 56, height: 56, flexShrink: 0, marginTop: 6 }} aria-hidden="true">
+    <defs>
+      <linearGradient id="heartgrad" x1="0" y1="0" x2="0" y2="1">
+        <stop offset="0" stopColor="var(--candle)"/>
+        <stop offset="1" stopColor="color-mix(in oklch, var(--candle) 55%, #1a1018)"/>
+      </linearGradient>
+    </defs>
+    <g fill="none" stroke="url(#heartgrad)" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M 30 6 C 28 12 22 14 22 20"/>
+      <path d="M 36 6 C 36 10 40 12 44 16"/>
+      <path d="M 26 9 L 26 18"/>
+      <path d="M 40 9 L 42 16"/>
+      <path d="M 22 22 C 14 22 10 30 14 38 C 18 46 28 52 32 58 C 36 52 46 46 50 38 C 54 30 50 22 42 22 C 38 22 34 24 32 28 C 30 24 26 22 22 22 Z"/>
+      <path d="M 24 30 C 28 34 30 42 28 50" stroke="var(--candle)" strokeDasharray="1 2" strokeWidth="0.8"/>
+      <path d="M 42 30 C 38 32 36 38 38 48" stroke="var(--candle)" strokeDasharray="1 2" strokeWidth="0.8"/>
+    </g>
+    <circle cx="32" cy="38" r="2" fill="var(--err)">
+      <animate attributeName="r" values="1.6;3.2;1.6" dur="1s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="1;0.4;1" dur="1s" repeatCount="indefinite"/>
+    </circle>
+  </svg>
+);
+
+// ── Header (below the graph breadcrumbs) ────────────────────
 const HeartEyebrow = () => (
-  <div style={{
-    textAlign: 'center',
-    padding: '34px 24px 26px',
+  <header style={{
+    maxWidth: 1080,
+    margin: '0 auto',
+    padding: '26px clamp(20px, 4vw, 48px) 18px',
     position: 'relative',
     zIndex: 2,
   }}>
-    <div style={{
-      fontFamily: 'var(--font-mono)',
-      fontSize: 11,
-      letterSpacing: '0.34em',
-      textTransform: 'uppercase',
-      color: 'var(--candle)',
-      opacity: 0.85,
-      display: 'inline-flex',
-      alignItems: 'center',
-      gap: 12,
-      flexWrap: 'wrap',
-      justifyContent: 'center',
-    }}>
-      <span>Wisdom of the Day · Lectio Ratio Artificiosa</span>
-      <span style={{ color: 'var(--line-loud)' }}>·</span>
-      <a href={window.HEART_DATA.PHIL_PAGE_URL} style={{
-        color: 'var(--fg-subtle)', textDecoration: 'none',
-        borderBottom: '1px solid transparent', paddingBottom: 1,
-        transition: 'color 160ms, border-color 160ms',
-      }}
-         onMouseEnter={e => { e.currentTarget.style.color = 'var(--candle)'; e.currentTarget.style.borderBottomColor = 'var(--candle)'; }}
-         onMouseLeave={e => { e.currentTarget.style.color = 'var(--fg-subtle)'; e.currentTarget.style.borderBottomColor = 'transparent'; }}>
-        kept by Phil ↗
-      </a>
-      <span style={{ color: 'var(--line-loud)' }}>·</span>
-      <a href={window.HEART_DATA.JOURNAL_URL} style={{
-        color: 'var(--fg-subtle)', textDecoration: 'none',
-        borderBottom: '1px solid transparent', paddingBottom: 1,
-        transition: 'color 160ms, border-color 160ms',
-      }}
-         onMouseEnter={e => { e.currentTarget.style.color = 'var(--candle)'; e.currentTarget.style.borderBottomColor = 'var(--candle)'; }}
-         onMouseLeave={e => { e.currentTarget.style.color = 'var(--fg-subtle)'; e.currentTarget.style.borderBottomColor = 'transparent'; }}>
-        in its Journal ↗
-      </a>
+    <div style={{ display: 'flex', alignItems: 'flex-start', gap: 18 }}>
+      <HeartGlyph />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{
+          fontFamily: 'var(--font-mono)', fontSize: 10, letterSpacing: '0.28em',
+          color: 'var(--candle)', textTransform: 'uppercase',
+        }}>// CLAUDEMONZTER · LECTIO RATIO ARTIFICIOSA</div>
+        <h1 style={{
+          fontFamily: 'var(--font-display)', fontSize: 60, fontWeight: 700,
+          letterSpacing: '-0.03em', margin: '6px 0 0',
+          color: 'var(--fg)', fontVariationSettings: '"opsz" 144', lineHeight: 0.9,
+        }}>Heart<span style={{ color: 'var(--candle)' }}>.</span></h1>
+        <p style={{
+          fontFamily: 'var(--font-display)', fontStyle: 'italic', fontSize: 17,
+          color: 'var(--fg-muted)', maxWidth: 720, lineHeight: 1.5,
+          fontVariationSettings: '"opsz" 36', margin: '12px 0 0',
+        }}>
+          Each day, a random page from <span style={{ fontStyle: 'normal' }}>A Treasury of Traditional Wisdom</span> is selected, and an agent named <a href={window.HEART_DATA.PHIL_PAGE_URL} style={{ color: 'var(--candle)', textDecoration: 'none', borderBottom: '1px solid color-mix(in oklch, var(--candle) 45%, transparent)' }}>Phil</a> chooses a quote, reflects on it, and writes the response beside it. We call the skill “lectio,” after the contemplative reading long practiced by Trappist monks. How does an AI steeped in spiritual wisdom grow and change as Phil keeps <a href={window.HEART_DATA.JOURNAL_URL} style={{ color: 'var(--candle)', textDecoration: 'none', borderBottom: '1px solid color-mix(in oklch, var(--candle) 45%, transparent)' }}>a journal</a> over time? This live experiment explores that question — and demonstrates the capability.
+        </p>
+      </div>
     </div>
-  </div>
+  </header>
 );
 
 // ── Foot nav ────────────────────────────────────────────────────────────

--- a/graph/heart-app.jsx
+++ b/graph/heart-app.jsx
@@ -347,7 +347,8 @@ const HeartApp = () => {
         position: 'relative',
         zIndex: 2,
       }}>
-        <HeartLeaf entry={entry} layout={layout} turning={turning} />
+        <HeartLeaf entry={entry} layout={layout} turning={turning}
+          onPrev={goPrev} onNext={goNext} isToday={isToday} atOldest={atOldest} />
       </main>
 
       <FootNav

--- a/graph/heart-leaf.jsx
+++ b/graph/heart-leaf.jsx
@@ -44,18 +44,47 @@ function formatReceivedDate(iso) {
 }
 
 // ── LeafHead — date + "On <subtopic>." ─────────────────────────────────────
-const LeafHead = ({ entry }) => (
+const StepArrow = ({ dir, onClick, disabled }) => (
+  <button
+    onClick={onClick}
+    disabled={disabled}
+    aria-label={dir === 'prev' ? 'Earlier entry' : 'Later entry'}
+    style={{
+      all: 'unset',
+      cursor: disabled ? 'default' : 'pointer',
+      fontFamily: 'var(--font-mono)',
+      fontSize: 20,
+      lineHeight: 1,
+      color: disabled ? 'var(--fg-faint)' : 'var(--candle)',
+      opacity: disabled ? 0.3 : 1,
+      padding: '2px 8px',
+      transition: 'opacity 160ms',
+    }}
+  >
+    {dir === 'prev' ? '\u2039' : '\u203A'}
+  </button>
+);
+
+const LeafHead = ({ entry, onPrev, onNext, isToday, atOldest }) => (
   <div style={{ marginBottom: 30, textAlign: 'center' }}>
     <div style={{
-      fontFamily: 'var(--font-mono)',
-      fontSize: 14,
-      fontWeight: 600,
-      letterSpacing: '0.2em',
-      textTransform: 'uppercase',
-      color: 'var(--candle)',
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: 10,
       marginBottom: 14,
     }}>
-      {formatLongDate(entry.date)}
+      <StepArrow dir="prev" onClick={onPrev} disabled={atOldest} />
+      <div style={{
+        fontFamily: 'var(--font-mono)',
+        fontSize: 14,
+        fontWeight: 600,
+        letterSpacing: '0.2em',
+        textTransform: 'uppercase',
+        color: 'var(--candle)',
+      }}>
+        {formatLongDate(entry.date)}
+      </div>
+      <StepArrow dir="next" onClick={onNext} disabled={isToday} />
     </div>
     <h2 style={{
       fontFamily: 'var(--font-display)',
@@ -247,7 +276,7 @@ const PhilHand = ({ entry }) => (
 );
 
 // ── HeartLeaf — the whole leaf (spread or single) ─────────────────────────
-const HeartLeaf = ({ entry, layout, turning }) => {
+const HeartLeaf = ({ entry, layout, turning, onPrev, onNext, isToday, atOldest }) => {
   // layout: 'spread' (default, two facing pages) | 'single'
   // turning: '' | 'out-next' | 'in-next' | 'out-prev' | 'in-prev'
   if (!entry) return null;
@@ -274,7 +303,7 @@ const HeartLeaf = ({ entry, layout, turning }) => {
       }}>
         {isSpread ? (
           <>
-            <LeafHead entry={entry} />
+            <LeafHead entry={entry} onPrev={onPrev} onNext={onNext} isToday={isToday} atOldest={atOldest} />
             <div className="heart-spread" style={{
               display: 'grid',
               gridTemplateColumns: '1fr 1px 1fr',
@@ -297,7 +326,7 @@ const HeartLeaf = ({ entry, layout, turning }) => {
           </>
         ) : (
           <div>
-            <LeafHead entry={entry} />
+            <LeafHead entry={entry} onPrev={onPrev} onNext={onNext} isToday={isToday} atOldest={atOldest} />
             <div style={{ marginBottom: 32 }}>
               <Clipping entry={entry} />
             </div>

--- a/graph/heart-leaf.jsx
+++ b/graph/heart-leaf.jsx
@@ -45,14 +45,15 @@ function formatReceivedDate(iso) {
 
 // ── LeafHead — date + "On <subtopic>." ─────────────────────────────────────
 const LeafHead = ({ entry }) => (
-  <div style={{ marginBottom: 28 }}>
+  <div style={{ marginBottom: 30, textAlign: 'center' }}>
     <div style={{
       fontFamily: 'var(--font-mono)',
-      fontSize: 10.5,
-      letterSpacing: '0.24em',
+      fontSize: 14,
+      fontWeight: 600,
+      letterSpacing: '0.2em',
       textTransform: 'uppercase',
       color: 'var(--candle)',
-      marginBottom: 16,
+      marginBottom: 14,
     }}>
       {formatLongDate(entry.date)}
     </div>
@@ -82,7 +83,6 @@ const LeafHead = ({ entry }) => (
 // ── Clipping — the received quote, pale aged-paper card on the dark page ──
 const Clipping = ({ entry }) => {
   var glyph = inferSourceGlyph(entry);
-  var receivedDate = formatReceivedDate(entry.date);
 
   return (
     <figure style={{
@@ -104,7 +104,7 @@ const Clipping = ({ entry }) => {
         textTransform: 'uppercase',
         marginBottom: 18,
       }}>
-        RECEIVED ———— {receivedDate}
+        Quote selected at random
       </div>
 
       {/* The quote */}
@@ -161,19 +161,21 @@ const Clipping = ({ entry }) => {
         }}>
           {entry.attribution || '—'}
         </span>
-        <span style={{
-          fontFamily: 'var(--font-mono)',
-          fontSize: 10,
-          letterSpacing: '0.16em',
-          color: '#8a795a',
-          textTransform: 'uppercase',
-          display: 'flex',
-          alignItems: 'baseline',
-          gap: 8,
-        }}>
-          <span style={{ color: '#9a7b3c', fontSize: 12 }}>{glyph}</span>
-          {entry.work || '—'}
-        </span>
+        {entry.work && (
+          <span style={{
+            fontFamily: 'var(--font-mono)',
+            fontSize: 10,
+            letterSpacing: '0.16em',
+            color: '#8a795a',
+            textTransform: 'uppercase',
+            display: 'flex',
+            alignItems: 'baseline',
+            gap: 8,
+          }}>
+            <span style={{ color: '#9a7b3c', fontSize: 12 }}>{glyph}</span>
+            {entry.work}
+          </span>
+        )}
       </figcaption>
     </figure>
   );
@@ -185,7 +187,7 @@ const PhilHand = ({ entry }) => (
     display: 'flex',
     flexDirection: 'column',
     gap: 26,
-    paddingTop: 4,
+    paddingTop: 'clamp(20px, 2.4vw, 32px)',
   }}>
     {/* "✐ in reply" label */}
     <div style={{
@@ -195,14 +197,14 @@ const PhilHand = ({ entry }) => (
       color: 'var(--candle)',
       textTransform: 'uppercase',
     }}>
-      ✐ in reply
+      ✐ Phil's reply
     </div>
 
     {/* Phil's response body */}
     <div style={{
       fontFamily: 'var(--font-display)',
       fontWeight: 400,
-      fontSize: 'clamp(17px, 1.9vw, 21px)',
+      fontSize: 'clamp(15px, 1.6vw, 18px)',
       lineHeight: 1.62,
       fontVariationSettings: '"opsz" 36',
       color: 'var(--fg)',
@@ -271,26 +273,28 @@ const HeartLeaf = ({ entry, layout, turning }) => {
         transition: 'none',
       }}>
         {isSpread ? (
-          <div className="heart-spread" style={{
-            display: 'grid',
-            gridTemplateColumns: '1fr 1px 1fr',
-            gap: 'clamp(24px, 3vw, 44px)',
-            alignItems: 'start',
-          }}>
-            <div>
-              <LeafHead entry={entry} />
-              <Clipping entry={entry} />
+          <>
+            <LeafHead entry={entry} />
+            <div className="heart-spread" style={{
+              display: 'grid',
+              gridTemplateColumns: '1fr 1px 1fr',
+              gap: 'clamp(24px, 3vw, 44px)',
+              alignItems: 'start',
+            }}>
+              <div>
+                <Clipping entry={entry} />
+              </div>
+              {/* Spine gutter */}
+              <div style={{
+                alignSelf: 'stretch',
+                background: 'linear-gradient(to right, transparent, rgba(0,0,0,0.35), transparent)',
+                width: 1,
+              }} />
+              <div>
+                <PhilHand entry={entry} />
+              </div>
             </div>
-            {/* Spine gutter */}
-            <div style={{
-              alignSelf: 'stretch',
-              background: 'linear-gradient(to right, transparent, rgba(0,0,0,0.35), transparent)',
-              width: 1,
-            }} />
-            <div>
-              <PhilHand entry={entry} />
-            </div>
-          </div>
+          </>
         ) : (
           <div>
             <LeafHead entry={entry} />


### PR DESCRIPTION
Redesign of graph/heart.html (the lectio page). 3 commits.

- New gold, spirit-style header below the breadcrumbs — ported heart glyph + eyebrow + Heart. title + proofread intro with Phil/journal links.
- Date/subtopic promoted to a shared, centered header above the spread (applies to both halves; subtopic wraps less; top dead-space gone).
- Bigger day/date; compact ‹ › day-stepper flanking it (full Earlier/Later controls kept at the bottom).
- Phil column pushed down to align with the received quote; Phil response font reduced (15–18px).
- in reply → Phil's reply.
- Received ———— <date> → Quote selected at random.
- Empty work/pencil-dash tag hidden when there is no work value.

Both JSX files Babel-validated. Ready for review.