### PR TITLE
Heart polish (post-#244 feedback)

### DIFF
--- a/graph/heart-app.jsx
+++ b/graph/heart-app.jsx
@@ -86,7 +86,7 @@ const HeartEyebrow = () => (
           color: 'var(--fg-muted)', maxWidth: 720, lineHeight: 1.5,
           fontVariationSettings: '"opsz" 36', margin: '12px 0 0',
         }}>
-          Each day, a random page from <span style={{ fontStyle: 'normal' }}>A Treasury of Traditional Wisdom</span> is selected, and an agent named <a href={window.HEART_DATA.PHIL_PAGE_URL} style={{ color: 'var(--candle)', textDecoration: 'none', borderBottom: '1px solid color-mix(in oklch, var(--candle) 45%, transparent)' }}>Phil</a> chooses a quote, reflects on it, and writes the response beside it. We call the skill “lectio,” after the contemplative reading long practiced by Trappist monks. How does an AI steeped in spiritual wisdom grow and change as Phil keeps <a href={window.HEART_DATA.JOURNAL_URL} style={{ color: 'var(--candle)', textDecoration: 'none', borderBottom: '1px solid color-mix(in oklch, var(--candle) 45%, transparent)' }}>a journal</a> over time? This live experiment explores that question — and demonstrates the capability.
+          Lectio is a skill that runs early each morning and explores what steeping an AI in spiritual wisdom does over time as it writes to its <a href={window.HEART_DATA.JOURNAL_URL} style={{ color: 'var(--candle)', textDecoration: 'none', borderBottom: '1px solid color-mix(in oklch, var(--candle) 45%, transparent)' }}>Journal</a>.
         </p>
       </div>
     </div>

--- a/graph/heart-leaf.jsx
+++ b/graph/heart-leaf.jsx
@@ -215,8 +215,8 @@ const PhilHand = ({ entry }) => (
   <div style={{
     display: 'flex',
     flexDirection: 'column',
-    gap: 26,
-    paddingTop: 'clamp(20px, 2.4vw, 32px)',
+    gap: 16,
+    paddingTop: 'clamp(8px, 1.2vw, 16px)',
   }}>
     {/* "✐ in reply" label */}
     <div style={{
@@ -258,7 +258,17 @@ const PhilHand = ({ entry }) => (
         color: 'var(--fg-subtle)',
         textTransform: 'uppercase',
       }}>
-        the philosopher · in residence
+        Resident Philosopher ·{' '}
+        <a href={window.HEART_DATA.PHIL_PAGE_URL} style={{
+          color: 'var(--fg-subtle)',
+          textDecoration: 'none',
+          borderBottom: '1px solid transparent',
+          transition: 'color 160ms, border-color 160ms',
+        }}
+          onMouseEnter={e => { e.currentTarget.style.color = 'var(--candle)'; e.currentTarget.style.borderBottomColor = 'var(--candle)'; }}
+          onMouseLeave={e => { e.currentTarget.style.color = 'var(--fg-subtle)'; e.currentTarget.style.borderBottomColor = 'transparent'; }}>
+          link to page ↗
+        </a>
       </span>
       <span style={{
         fontFamily: 'var(--font-hand)',


### PR DESCRIPTION
Post-#244 heart polish. #244 (header + day-stepper) merged at 19:16; these later changes came after and were never in main.

- Header copy shrunk to ~2 lines; Phil link relocated out of the header.
- New body: “Lectio is a skill that runs early each morning and explores what steeping an AI in spiritual wisdom does over time as it writes to its Journal.”
- Phil reply/response nudged up + label-to-body gap tightened.
- Sign-off: the philosopher · in residence → Resident Philosopher · link to page ↗ (links to phil.html).

Both JSX files Babel-validated. Clean diff off current main (2 files).