### PR TITLE
SEO injector — house-budget + house-timeline (head tags + noindex)

### DIFF
--- a/agents/house/house-budget.html
+++ b/agents/house/house-budget.html
@@ -4,6 +4,20 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Renovation Budget — Davis St</title>
+
+<!-- ── Social / SEO (meta1 injector) ────────────────────── -->
+<meta name="robots" content="noindex" />
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="Renovation Budget — Claudemonzter" />
+<meta property="og:description" content="The live renovation budget for the Davis St property — every expense tracked against the total. A working data surface wired to a Sheet, not a mockup." />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/agents/house/house-budget.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
   <link rel="stylesheet" href="https://jeremymontz.github.io/Meta1/design-system/fonts.css">
   <link rel="stylesheet" href="https://jeremymontz.github.io/Meta1/design-system/colors_and_type.css">
   <!-- Site chrome (React) -->

--- a/agents/house/house-timeline.html
+++ b/agents/house/house-timeline.html
@@ -4,6 +4,20 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Renovation Timeline — Davis St</title>
+
+<!-- ── Social / SEO (meta1 injector) ────────────────────── -->
+<meta name="robots" content="noindex" />
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="Renovation Timeline — Claudemonzter" />
+<meta property="og:description" content="The Davis St renovation timeline — phases and milestones laid out as a delivery schedule." />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/agents/house/house-timeline.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
   <link rel="stylesheet" href="https://jeremymontz.github.io/Meta1/design-system/fonts.css">
   <link rel="stylesheet" href="https://jeremymontz.github.io/Meta1/design-system/colors_and_type.css">
   <!-- Site chrome (React) -->


### PR DESCRIPTION
First run of the mechanical head-tag injector, on the two House renovation tools.

- Head tags (`og:*`, `twitter:card`, favicon) added from each page's `<title>` + SITE_INDEX `note`.
- **`noindex`** on both — they name the Davis St property; this keeps them out of public search while link previews still work when you share them (unfurlers ignore robots).
- `og:title` genericized (drops 'Davis St' from the share card); the browser `<title>` is unchanged.

Injector is idempotent (skips pages that already have og tags).