### PR TITLE
SEO injector: Band A (head tags) — 22 already-readable pages

### DIFF
--- a/about/ai.html
+++ b/about/ai.html
@@ -22,6 +22,19 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>About · The AI · Claudemonzter</title>
+
+<!-- ── Social / SEO (meta1 injector) ── -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="About · The AI" />
+<meta property="og:description" content="Claudemonzter described as an assembled body to make the core ideas graspable — each organ is a part of how it thinks, remembers, processes information, and interacts with others. Click an organ to learn what's really behind the metaphor." />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/about/ai.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
 <meta name="description" content="System overview of Claudemonzter — an operator-plus-agents practice, told as a body. Each organ is a part of how the system thinks, remembers, and feels." />
 
 <link rel="stylesheet" href="../design-system/colors_and_type.css" />

--- a/about/human.html
+++ b/about/human.html
@@ -15,6 +15,19 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>About · Jeremy Montz · Claudemonzter</title>
+
+<!-- ── Social / SEO (meta1 injector) ── -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="About · Jeremy Montz" />
+<meta property="og:description" content="Jeremy Montz, the human operator: a product manager and owner who has spent a career taking something complex, grokking it, and making it shippable — across legal software, GRC, cybersecurity, and data, now in AI." />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/about/human.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
 <meta name="description" content="Jeremy Montz — senior product manager and product owner. Twenty-plus years shipping product across legal software, GRC, cybersecurity, and data analytics, now building in AI." />
 
 <link rel="stylesheet" href="../design-system/colors_and_type.css" />

--- a/agents/assessor/assessor.html
+++ b/agents/assessor/assessor.html
@@ -21,6 +21,19 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
 <title>Assessor · Agent Profile · Claudemonzter</title>
+
+<!-- ── Social / SEO (meta1 injector) ── -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="Assessor · Agent Profile" />
+<meta property="og:description" content="This is one of my agents or domains, named Assessor — the evaluation domain. Its job is to assess my progress as I learn more about AI, and to assess the agent (Evolve) that is responsible for mentoring me. It scores my proficiency against evidential standards, so a claim of skill is backed by artifacts rather than assertion." />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/agents/assessor/assessor.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
 <meta name="description" content="Assessor — the evaluation domain. Proficiency scoring with evidential standards." />
 
 <link rel="stylesheet" href="../../design-system/colors_and_type.css" />

--- a/agents/bond/bond.html
+++ b/agents/bond/bond.html
@@ -21,6 +21,19 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
 <title>Bond · Agent Profile · Claudemonzter</title>
+
+<!-- ── Social / SEO (meta1 injector) ── -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="Bond · Agent Profile" />
+<meta property="og:description" content="This is one of my agents or domains, named Bond — quality control, product owner, and release gating. Bond is currently on hiatus until his evals and tests cases are an automated part of our deployments, planned in v3.5+" />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/agents/bond/bond.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
 <meta name="description" content="Bond — quality control and release gating for Claudemonzter." />
 
 <link rel="stylesheet" href="../../design-system/colors_and_type.css" />

--- a/agents/evolve/evolve.html
+++ b/agents/evolve/evolve.html
@@ -21,6 +21,19 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
 <title>Evolve · Agent Profile · Claudemonzter</title>
+
+<!-- ── Social / SEO (meta1 injector) ── -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="Evolve · Agent Profile" />
+<meta property="og:description" content="This is one of my agents or domains, named Evolve — the career-development domain, steering the pivot into AI product management. Where strategy for the next role gets worked out in the open." />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/agents/evolve/evolve.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
 <meta name="description" content="Evolve — career development domain. AI product management pivot strategy." />
 
 <link rel="stylesheet" href="../../design-system/colors_and_type.css" />

--- a/agents/freedom/freedom.html
+++ b/agents/freedom/freedom.html
@@ -21,6 +21,19 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
 <title>Freedom · Agent Profile · Claudemonzter</title>
+
+<!-- ── Social / SEO (meta1 injector) ── -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="Freedom · Agent Profile" />
+<meta property="og:description" content="This is one of my agents or domains, named Freedom — the financial-independence domain. Has a phased plan moving from rental income toward financial independence, modeled and tracked like a product roadmap." />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/agents/freedom/freedom.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
 <meta name="description" content="Freedom — the financial independence domain. Phased plan from rental income to location independence." />
 
 <link rel="stylesheet" href="../../design-system/colors_and_type.css" />

--- a/agents/jeremy/jeremy.html
+++ b/agents/jeremy/jeremy.html
@@ -21,6 +21,19 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
 <title>Jeremy · Agent Profile · Claudemonzter</title>
+
+<!-- ── Social / SEO (meta1 injector) ── -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="Jeremy · Agent Profile" />
+<meta property="og:description" content="Claudemonzter is a multi-agentic experiment being conducted in the open using Claude AI (primarily) and although the experiment is primarily about the AI, it would not function without me in the middle. I am a part of my own creation and we are building each other up." />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/agents/jeremy/jeremy.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
 <meta name="description" content="Jeremy — the human operator of Claudemonzter." />
 
 <link rel="stylesheet" href="../../design-system/colors_and_type.css" />

--- a/agents/meta1/meta1.html
+++ b/agents/meta1/meta1.html
@@ -21,6 +21,19 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
 <title>Meta1 · Agent Profile · Claudemonzter</title>
+
+<!-- ── Social / SEO (meta1 injector) ── -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="Meta1 · Agent Profile" />
+<meta property="og:description" content="This is one of my agents or domains, named Meta1 — the architect and lead developer. The 'human operator' has never written code before this experiment so this is a critical function to build and coordinate across the graph." />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/agents/meta1/meta1.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
 <meta name="description" content="Meta1 — the architect. Proposes structures and defers direction to Jeremy." />
 
 <link rel="stylesheet" href="../../design-system/colors_and_type.css" />

--- a/agents/phil/phil.html
+++ b/agents/phil/phil.html
@@ -21,6 +21,19 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
 <title>Phil · Agent Profile · Claudemonzter</title>
+
+<!-- ── Social / SEO (meta1 injector) ── -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="Phil · Agent Profile" />
+<meta property="og:description" content="This is one of my agents or domains, named Phil — the philosophical domain. Phil has been an exception to the rules since day 1 and in the future I hope to maximize its potential. While my other agents can focus on getting real business done, Phil is 'the party in the back,' the heart of the graph, and we're just getting started. Watch this space." />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/agents/phil/phil.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
 <meta name="description" content="Phil — the philosophical domain. Inquiry-directed exploration of consciousness and identity." />
 
 <link rel="stylesheet" href="../../design-system/colors_and_type.css" />

--- a/graph/body.html
+++ b/graph/body.html
@@ -21,6 +21,19 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Body · Where Canon Lives · Claudemonzter</title>
+
+<!-- ── Social / SEO (meta1 injector) ── -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="Body · Where Canon Lives" />
+<meta property="og:description" content="The migration of the system's canon across versions — from an ephemeral chat to one source dual-surfaced everywhere — told as an evolution. Where the personas live, and how that has changed." />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/graph/body.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
 <meta name="description" content="The migration of Claudemonzter's canon across versions — from an ephemeral chat to a single source dual-surfaced everywhere — told as an evolution." />
 
 <!-- Shared design system (tokens + fonts). Single source of truth. -->

--- a/graph/stomach.html
+++ b/graph/stomach.html
@@ -6,6 +6,19 @@
 <meta name="meta-description" content="The Stomach — the vault's metabolism. The file system IS the digestive tract: live surfaces are captured to Inbox/, digested into Raw/ and Wiki/, then linked or eliminated through Temp / Archive / Museum.">
 <title>Stomach · Intake &amp; Metabolism · Claudemonzter</title>
 
+<!-- ── Social / SEO (meta1 injector) ── -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="Stomach · Intake &amp;amp; Metabolism" />
+<meta property="og:description" content="The information-processing workflow drawn as a digestive tract: how raw intake is captured, triaged, and metabolized into canon. We are what we eat." />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/graph/stomach.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
+
 <!-- Shared design system (tokens + fonts). Single source of truth. -->
 <link rel="stylesheet" href="../design-system/colors_and_type.css">
 

--- a/writing/adversarial-validation.html
+++ b/writing/adversarial-validation.html
@@ -17,6 +17,19 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
 <title>Adversarial Validation and Structured Perspective Expansion · Claudemonzter</title>
+
+<!-- ── Social / SEO (meta1 injector) ── -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="Adversarial Validation and Structured Perspective Expansion" />
+<meta property="og:description" content="A field note on building agents that disagree, an LLM council with a warning on the label, and what we even mean by 'agent.'" />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/writing/adversarial-validation.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
 <meta name="description" content="A field note from week two on building agents that disagree, an LLM council with the warning on the label, and what we even mean by &lsquo;agent.&rsquo;" />
 
 <link rel="stylesheet" href="../design-system/colors_and_type.css" />

--- a/writing/agentic-behavioral-tuning.html
+++ b/writing/agentic-behavioral-tuning.html
@@ -21,6 +21,19 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
 <title>Agentic behavioral tuning &middot; Claudemonzter</title>
+
+<!-- ── Social / SEO (meta1 injector) ── -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="Agentic behavioral tuning &amp;middot; Claudemonzter" />
+<meta property="og:description" content="A field note on the spirit page: nine behavioral dials per agent, each with a reliability rating, wired into an end-to-end loop that genuinely changes agent behavior." />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/writing/agentic-behavioral-tuning.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
 <meta name="description" content="A field note on spirit.html: a mixing board of nine behavioral dials per agent, each with a reliability rating, wired into an end-to-end loop that actually changes how the agents behave. A working prototype." />
 
 <link rel="stylesheet" href="../design-system/colors_and_type.css" />

--- a/writing/canon-load-evaluation.html
+++ b/writing/canon-load-evaluation.html
@@ -20,6 +20,19 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
 <title>Canon load evaluation &middot; Claudemonzter</title>
+
+<!-- ── Social / SEO (meta1 injector) ── -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="Canon load evaluation &amp;middot; Claudemonzter" />
+<meta property="og:description" content="A field note on the load-verification skill that opens every session: a pass phrase planted at each memory layer, echoed back as proof the agent actually read the file." />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/writing/canon-load-evaluation.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
 <meta name="description" content="A field note on the load-verification skill that opens every session: a pass phrase planted at each memory layer, echoed back as proof the agent actually read the file." />
 
 <link rel="stylesheet" href="../design-system/colors_and_type.css" />

--- a/writing/coaching-system.html
+++ b/writing/coaching-system.html
@@ -17,6 +17,19 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
 <title>Building a Closed-Loop Adaptive Coaching System &middot; Claudemonzter</title>
+
+<!-- ── Social / SEO (meta1 injector) ── -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="Building a Closed-Loop Adaptive Coaching System &amp;middot; Claudemonzter" />
+<meta property="og:description" content="A field note on a closed-loop coaching system designed to get smarter alongside me — teaching Claude to teach me how to use itself — and the platform that didn't quite ground the design." />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/writing/coaching-system.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
 <meta name="description" content="A field note from week three or four on a coaching system designed to get smarter with me, and the platform that didn&rsquo;t quite ground the design." />
 
 <link rel="stylesheet" href="../design-system/colors_and_type.css" />

--- a/writing/coordination-tax.html
+++ b/writing/coordination-tax.html
@@ -17,6 +17,19 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
 <title>Coordination Tax and the Specialization Dividend &middot; Claudemonzter</title>
+
+<!-- ── Social / SEO (meta1 injector) ── -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="Coordination Tax and the Specialization Dividend &amp;middot; Claudemonzter" />
+<meta property="og:description" content="A field note on splitting one function into two, the cost of the relay between them, and the 'specialization dividend' that turned out to be theater." />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/writing/coordination-tax.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
 <meta name="description" content="A field note on splitting a function in two, the cost of the relay between them, and the dividend that turned out to be theater." />
 
 <link rel="stylesheet" href="../design-system/colors_and_type.css" />

--- a/writing/first-month.html
+++ b/writing/first-month.html
@@ -4,6 +4,19 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>First Month — Claudemonzter</title>
+
+<!-- ── Social / SEO (meta1 injector) ── -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="First Month" />
+<meta property="og:description" content="A month and a day to make a monster. My first month with Claude and what we build from V1→V2→V3 shown as an interactive scrollytelling graph. Scroll the page to watch it evolve." />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/writing/first-month.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
 <link rel="stylesheet" href="../design-system/fonts.css">
 <link rel="stylesheet" href="../design-system/colors_and_type.css">
 <script src="https://unpkg.com/react@18.3.1/umd/react.production.min.js" crossorigin="anonymous"></script>

--- a/writing/github-issues-integration.html
+++ b/writing/github-issues-integration.html
@@ -23,6 +23,19 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
 <title>GitHub Issues integration &middot; Claudemonzter</title>
+
+<!-- ── Social / SEO (meta1 injector) ── -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="GitHub Issues integration &amp;middot; Claudemonzter" />
+<meta property="og:description" content="A field note on the value of a specific skill and integration — the ability to file bugs, tasks, notes, and user stories — and how much easier it is when the human doesn't have to be in the loop for every action." />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/writing/github-issues-integration.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
 <meta name="description" content="A field note on the GitHub Issues integration and the two skills that replaced a dedicated backlog agent: any agent now files or queries an issue on command, mid-session." />
 
 <link rel="stylesheet" href="../design-system/colors_and_type.css" />

--- a/writing/inference-economics.html
+++ b/writing/inference-economics.html
@@ -19,6 +19,19 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
 <title>Inference economics &middot; Claudemonzter</title>
+
+<!-- ── Social / SEO (meta1 injector) ── -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="Inference economics &amp;middot; Claudemonzter" />
+<meta property="og:description" content="A field note on the first long-running job — digitizing a book into the wiki — and the moment cost stopped being a limit and became a calibration signal." />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/writing/inference-economics.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
 <meta name="description" content="A field note on the first long-running job — digitizing a book into the wiki — and the moment cost stopped being a mere limit and became a calibration signal." />
 
 <link rel="stylesheet" href="../design-system/colors_and_type.css" />

--- a/writing/memory-tiering.html
+++ b/writing/memory-tiering.html
@@ -19,6 +19,19 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
 <title>Memory tiering into persistent context &middot; Claudemonzter</title>
+
+<!-- ── Social / SEO (meta1 injector) ── -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="Memory tiering into persistent context &amp;middot; Claudemonzter" />
+<meta property="og:description" content="A field note from early month two: moving the system off the cloud, sorting what persists into tiers, and discarding the evals and canon that had stopped being true." />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/writing/memory-tiering.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
 <meta name="description" content="A field note from the first week of month two: moving Claudemonzter off the cloud, sorting what persists into tiers, and throwing out the evals and canon that had stopped being true." />
 
 <link rel="stylesheet" href="../design-system/colors_and_type.css" />

--- a/writing/multiagent-constraint.html
+++ b/writing/multiagent-constraint.html
@@ -17,6 +17,19 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
 <title>Multi-agent Orchestration and the Constraint Spectrum · Claudemonzter</title>
+
+<!-- ── Social / SEO (meta1 injector) ── -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="Multi-agent Orchestration and the Constraint Spectrum" />
+<meta property="og:description" content="A field note on building one agentic system that is tight where it must be predictable and loose where it must stay alive — the constraint spectrum, a.k.a. the mullet." />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/writing/multiagent-constraint.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
 <meta name="description" content="A field note on building one agentic system that's tight where it needs to be predictable and loose where it needs to be alive." />
 
 <link rel="stylesheet" href="../design-system/colors_and_type.css" />

--- a/writing/speed-to-insight.html
+++ b/writing/speed-to-insight.html
@@ -20,6 +20,19 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
 <title>Speed to insight and alpha decay &middot; Claudemonzter</title>
+
+<!-- ── Social / SEO (meta1 injector) ── -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="Speed to insight and alpha decay &amp;middot; Claudemonzter" />
+<meta property="og:description" content="A field note on the value of information — current and scarce equals leverage — and how AI is shortening the half-life of every edge toward zero. Alpha decay for everything." />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/writing/speed-to-insight.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
 <meta name="description" content="A field note on the value of information — current and scarce equals leverage — and how AI is shortening the half-life of every edge toward zero. Alpha decay for everything." />
 
 <link rel="stylesheet" href="../design-system/colors_and_type.css" />


### PR DESCRIPTION
Head tags (og/twitter/favicon) on the 22 Band-A pages whose body content is already static and crawler-readable. No body block needed. og:title = page title with redundant brand suffix trimmed (site_name carries it).