### PR TITLE
SEO injector: Band C (head tags + hidden summary) — 10 JS-rendered pages

### DIFF
--- a/about/history.html
+++ b/about/history.html
@@ -14,6 +14,19 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>About · Our History · Claudemonzter</title>
+
+<!-- ── Social / SEO (meta1 injector) ── -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="About · Our History" />
+<meta property="og:description" content="The operator-plus-agents story, told month by month as interactive graphs. How the system evolved from an ephemeral chat into... whatever this is. See another depiction of this at body and watch it evolve." />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/about/history.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
 <meta name="description" content="The operator-plus-agents story, told month by month as interactive graphs." />
 
 <link rel="stylesheet" href="../design-system/colors_and_type.css" />
@@ -47,6 +60,11 @@
 </style>
 </head>
 <body>
+<div hidden data-seo-summary>
+<h1>About · Our History</h1>
+<p>The operator-plus-agents story, told month by month as interactive graphs. How the system evolved from an ephemeral chat into... whatever this is. See another depiction of this at body and watch it evolve.</p>
+</div>
+
 
 <div id="root"></div>
 

--- a/agents/phil/journal.html
+++ b/agents/phil/journal.html
@@ -3,6 +3,19 @@
 <head>
 <meta charset="utf-8"/>
 <title>The Journal · Heart · Claudemonzter</title>
+
+<!-- ── Social / SEO (meta1 injector) ── -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="The Journal · Heart" />
+<meta property="og:description" content="Every entry of Phil's daily lectio, plus an ink-spatter word-cloud of the language he reaches for. A persona's output accumulating into a body of voice over time." />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/agents/phil/journal.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <meta name="description" content="The Journal — every entry of Phil's daily lectio, plus an ink-spatter cloud of the words he reaches for." />
 
@@ -43,6 +56,11 @@
 </head>
 
 <body>
+<div hidden data-seo-summary>
+<h1>The Journal · Heart</h1>
+<p>Every entry of Phil's daily lectio, plus an ink-spatter word-cloud of the language he reaches for. A persona's output accumulating into a body of voice over time.</p>
+</div>
+
 
 <div class="page">
 

--- a/dashboard.html
+++ b/dashboard.html
@@ -4,6 +4,19 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Agent Status — Claudemonzter Lab</title>
+
+<!-- ── Social / SEO (meta1 injector) ── -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="Agent Status" />
+<meta property="og:description" content="This not a mockup, but a live agent-status dashboard: every agent's current state, derived from its latest check-in. The operational heartbeat of the lab." />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/dashboard.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
 <link rel="stylesheet" href="design-system/colors_and_type.css" />
 <style>
 /* ── Dashboard-local tokens (not in design system) ──────── */
@@ -101,6 +114,11 @@ h1 span { color: var(--accent); font-style: italic; font-variation-settings: "op
 <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" crossorigin="anonymous"></script>
 </head>
 <body>
+<div hidden data-seo-summary>
+<h1>Agent Status</h1>
+<p>This not a mockup, but a live agent-status dashboard: every agent's current state, derived from its latest check-in. The operational heartbeat of the lab.</p>
+</div>
+
 
 <!-- ── Site chrome (React) ─────────────────────────────────── -->
 <div id="topnav-mount"></div>

--- a/graph/brain.html
+++ b/graph/brain.html
@@ -3,6 +3,19 @@
 <head>
 <meta charset="utf-8"/>
 <title>Brain · A vault of research · Claudemonzter</title>
+
+<!-- ── Social / SEO (meta1 injector) ── -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="Brain · A vault of research" />
+<meta property="og:description" content="The knowledge base drawn as a vault graph over a real anatomical brain plate: five document regions, five memory layers. How research is stored and retrieved." />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/graph/brain.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <meta name="description" content="Brain — Claudemonzter's knowledge base as a vault graph drawn over a real anatomical brain plate. Five document regions, five memory layers." />
 
@@ -65,6 +78,11 @@
 </head>
 
 <body>
+<div hidden data-seo-summary>
+<h1>Brain · A vault of research</h1>
+<p>The knowledge base drawn as a vault graph over a real anatomical brain plate: five document regions, five memory layers. How research is stored and retrieved.</p>
+</div>
+
 
 <div class="page">
 

--- a/graph/faces.html
+++ b/graph/faces.html
@@ -4,6 +4,19 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Faces · Agent Status — Claudemonzter</title>
+
+<!-- ── Social / SEO (meta1 injector) ── -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="Faces · Agent Status" />
+<meta property="og:description" content="Not a mock-up. A live agent roster showing three states— idle / active / open — with a fly-in dossier pairing each agent's actual status with its persona settings and latest session history. Visit each agents page to learn more about what they do." />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/graph/faces.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
 <meta name="description" content="The Faces — a glanceable agent roster (idle / active / open) with a fly-in dossier: live status card + persona card. The portrait companion to the dashboard." />
 
 <link rel="stylesheet" href="../design-system/colors_and_type.css" />
@@ -144,6 +157,11 @@
 </head>
 
 <body>
+<div hidden data-seo-summary>
+<h1>Faces · Agent Status</h1>
+<p>Not a mock-up. A live agent roster showing three states— idle / active / open — with a fly-in dossier pairing each agent's actual status with its persona settings and latest session history. Visit each agents page to learn more about what they do.</p>
+</div>
+
 <div class="page">
 
   <!-- shared site chrome -->

--- a/graph/hands.html
+++ b/graph/hands.html
@@ -6,6 +6,19 @@
 <meta name="meta-description" content="The Hands — Claude's inherent primitives, the skills I built on top, and the real services I wired them into.">
 <title>Hands · Skills & Capabilities · Claudemonzter</title>
 
+<!-- ── Social / SEO (meta1 injector) ── -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="Hands · Skills &amp; Capabilities" />
+<meta property="og:description" content="What the system can do: Claude has out-of-the-box capabilities but the real value is be able to easily build custom skills and live integrations to make the monster DO things." />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/graph/hands.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
+
 <!-- Shared design system (tokens + fonts). Single source of truth. -->
 <link rel="stylesheet" href="../design-system/colors_and_type.css">
 
@@ -126,6 +139,11 @@ body{
 </style>
 </head>
 <body>
+<div hidden data-seo-summary>
+<h1>Hands · Skills &amp; Capabilities</h1>
+<p>What the system can do: Claude has out-of-the-box capabilities but the real value is be able to easily build custom skills and live integrations to make the monster DO things.</p>
+</div>
+
 <div class="page">
 
   <!-- shared chrome mounts -->

--- a/graph/heart.html
+++ b/graph/heart.html
@@ -3,6 +3,19 @@
 <head>
 <meta charset="utf-8"/>
 <title>Heart · Wisdom of the Day · Claudemonzter</title>
+
+<!-- ── Social / SEO (meta1 injector) ── -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="Heart · Wisdom of the Day" />
+<meta property="og:description" content="Not a mock-up. The system's contemplative pulse, refreshed each day with a randomized reading from A Treasury of Traditional Wisdom. Includes a thoughtful response from Phil that gets written into his journal and forms a word cloud. What is on an AI's mind when you feed it mystics?" />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/graph/heart.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <meta name="description" content="Heart — Phil's daily reading from A Treasury of Traditional Wisdom, and his response through the Map." />
 
@@ -104,6 +117,11 @@
 </head>
 
 <body>
+<div hidden data-seo-summary>
+<h1>Heart · Wisdom of the Day</h1>
+<p>Not a mock-up. The system's contemplative pulse, refreshed each day with a randomized reading from A Treasury of Traditional Wisdom. Includes a thoughtful response from Phil that gets written into his journal and forms a word cloud. What is on an AI's mind when you feed it mystics?</p>
+</div>
+
 
 <div class="page">
 

--- a/graph/memory.html
+++ b/graph/memory.html
@@ -3,6 +3,19 @@
 <head>
 <meta charset="utf-8"/>
 <title>Memory · Layer Map · Claudemonzter</title>
+
+<!-- ── Social / SEO (meta1 injector) ── -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="Memory · Layer Map" />
+<meta property="og:description" content="The configuration layers: how context is tiered from user settings, to claude.md and project domains, and managing ephermeral memory as it moves from the inbox to the wiki. How a thought becomes canon." />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/graph/memory.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <link rel="stylesheet" href="../design-system/colors_and_type.css"/>
 <script src="https://unpkg.com/react@18.3.1/umd/react.production.min.js" crossorigin="anonymous"></script>
@@ -59,6 +72,11 @@
 </style>
 </head>
 <body>
+<div hidden data-seo-summary>
+<h1>Memory · Layer Map</h1>
+<p>The configuration layers: how context is tiered from user settings, to claude.md and project domains, and managing ephermeral memory as it moves from the inbox to the wiki. How a thought becomes canon.</p>
+</div>
+
 
 <!-- ─── SITE CHROME (React) ─────────────────────────────────── -->
 <div id="topnav-mount"></div>

--- a/graph/spirit.html
+++ b/graph/spirit.html
@@ -3,6 +3,19 @@
 <head>
 <meta charset="utf-8"/>
 <title>Spirit · Persona Matrix · Claudemonzter</title>
+
+<!-- ── Social / SEO (meta1 injector) ── -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="Spirit · Persona Matrix" />
+<meta property="og:description" content="Not a mock-up. The persona matrix — a mixing board of behavioral dials per agent, each with a reliability rating. Changes get written to a backend and then a skill updates the grounding docs on my local disk, that actually changes how the agents behave. Under Testing" />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/graph/spirit.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <link rel="stylesheet" href="../design-system/colors_and_type.css"/>
 <script src="https://unpkg.com/react@18.3.1/umd/react.production.min.js" crossorigin="anonymous"></script>
@@ -129,6 +142,11 @@
 </style>
 </head>
 <body>
+<div hidden data-seo-summary>
+<h1>Spirit · Persona Matrix</h1>
+<p>Not a mock-up. The persona matrix — a mixing board of behavioral dials per agent, each with a reliability rating. Changes get written to a backend and then a skill updates the grounding docs on my local disk, that actually changes how the agents behave. Under Testing</p>
+</div>
+
 
 <!-- ─── SITE CHROME (React) ─────────────────────────────────── -->
 <div id="topnav-mount"></div>

--- a/writing.html
+++ b/writing.html
@@ -4,6 +4,19 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Writing · Claudemonzter Lab</title>
+
+<!-- ── Social / SEO (meta1 injector) ── -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="Writing" />
+<meta property="og:description" content="Field notes, essays, and lab logs from the operator. The writing surface where each build gets a plain-language post-mortem: what was attempted, what broke, and what it proves." />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/writing.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
 <meta name="description" content="Field notes, essays, and lab logs from the operator." />
 
 <link rel="stylesheet" href="design-system/colors_and_type.css" />
@@ -36,6 +49,11 @@
 <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
 </head>
 <body>
+<div hidden data-seo-summary>
+<h1>Writing</h1>
+<p>Field notes, essays, and lab logs from the operator. The writing surface where each build gets a plain-language post-mortem: what was attempted, what broke, and what it proves.</p>
+</div>
+
 
 <div id="root"></div>
 


### PR DESCRIPTION
Head tags PLUS a hidden static summary block on the 10 Band-C pages whose body is JS-rendered (empty in raw HTML). The hidden `<div hidden data-seo-summary>` carries the page's title + SITE_INDEX note so no-JS crawlers/LLM fetchers get real content. index/portfolio (Band B) are intentionally excluded — they go with the README rewrite.