### PR TITLE
SEO Band B — index + portfolio (titles + head tags + hidden summary)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,20 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Lab Homepage</title>
+<title>Jeremy Montz — Claudemonzter · AI Product Lab</title>
+
+<!-- ── Social / SEO (meta1) ── -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="Jeremy Montz — Claudemonzter" />
+<meta property="og:description" content="The front door to the lab: a senior product manager running a multi-agent AI 'graph' in public — one operator plus a crew of agents, building the very site you're standing in. Start here, then follow any organ deeper." />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/index.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
 <meta name="description" content="Senior Product Manager and Owner running a multi-agentic graph AI lab in public." />
 
 <link rel="stylesheet" href="design-system/colors_and_type.css" />
@@ -69,6 +82,13 @@
 <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
 </head>
 <body>
+<div hidden data-seo-summary>
+<h1>Jeremy Montz — building Claudemonzter</h1>
+<p>Professional product-builder by day, mad scientist by night. Claudemonzter is my first home-built multi-agent laboratory — a learning experiment I'm running in public to find out what these LLMs can actually do.</p>
+<p>One graph, three projects, seven domains, and a human: 8 agents (1 human), 16 custom skills, three architecture generations (V1 to V3) in three months. I had never written code or used an AI tool before March 2026.</p>
+<p>Start here, then follow any organ deeper.</p>
+</div>
+
 
 <div id="root"></div>
 

--- a/portfolio.html
+++ b/portfolio.html
@@ -3,7 +3,20 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Jeremy Montz · Portfolio</title>
+<title>Jeremy Montz — Portfolio · Claudemonzter</title>
+
+<!-- ── Social / SEO (meta1) ── -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Claudemonzter" />
+<meta property="og:title" content="Jeremy Montz — Portfolio" />
+<meta property="og:description" content="Selected product work, out in the open. A career spent pointing engineering, design, and analytics teams at a problem until it shipped — now done solo with a pack of agents." />
+<meta property="og:url" content="https://jeremymontz.github.io/Meta1/portfolio.html" />
+<meta property="og:image" content="https://jeremymontz.github.io/Meta1/design-system/assets/og-card.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Operation: Claudemonzter — a multi-agent AI lab depicted as a creature on an operating table." />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="icon" type="image/svg+xml" href="/Meta1/design-system/assets/favicon.svg" />
 <meta name="description" content="Senior product manager and product owner. Selected work, out in the open." />
 
 <link rel="stylesheet" href="design-system/colors_and_type.css" />
@@ -36,6 +49,13 @@
 <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
 </head>
 <body>
+<div hidden data-seo-summary>
+<h1>Product work, out in the open — Jeremy Montz</h1>
+<p>I've spent a career leading teams — engineers, designers, analysts — pointed at a problem until it shipped. Now there's no team: just me and a crew of AI agents, building the very site you're standing in.</p>
+<p>The whole of Claudemonzter — every page and link here — is the proof of what one product person and a pack of agents can actually ship: competencies the system actually exercises, a live GitHub commit stream, and selected lab projects.</p>
+<p>Open to AI-native product roles — contract or full-time, remote.</p>
+</div>
+
 
 <div id="root"></div>
 


### PR DESCRIPTION
Closes the SEO rollout's flagship pages.

- Real `<title>`s — fixes the anonymous `Lab Homepage`.
- `og:*` / `twitter:card` / favicon.
- Hidden `data-seo-summary` carrying each page's **real authored content** (lifted from its `PAGE_` const, not invented) so no-JS crawlers/LLM fetchers get the substance — including portfolio's 'Open to AI-native product roles' signal.

Visible pages are unchanged (React still renders them); blocks are crawler-only.