### PR TITLE
Portfolio hero — hard-stats strip

### DIFF
--- a/components/PortfolioMain.jsx
+++ b/components/PortfolioMain.jsx
@@ -6,6 +6,7 @@
 // Sections: Hero → 01 What It Proves (stub) → 02 Live from the Lab → 03 The Work → Reach.
 
 const PG = (typeof window !== 'undefined' && window.PAGE_PORTFOLIO) || {};
+const ST = (typeof window !== 'undefined' && window.STATS) || [];
 
 const PortfolioMain = () => {
   return (
@@ -58,6 +59,17 @@ const PortfolioHero = () => {
               </p>
             );
           })}
+
+          {ST.length ? (
+            <div style={{ marginTop: 30, paddingTop: 22, borderTop: '1px solid var(--line)', display: 'flex', flexWrap: 'wrap', gap: 40 }}>
+              {ST.map((s, i) => (
+                <div key={i}>
+                  <div style={{ fontFamily: 'var(--font-display)', fontWeight: 700, fontSize: 42, lineHeight: 1, letterSpacing: '-0.02em', color: 'var(--fg)', fontVariationSettings: '"opsz" 80' }}>{s.value}</div>
+                  <div style={{ marginTop: 6, fontFamily: 'var(--font-mono)', fontSize: 11, letterSpacing: '0.14em', textTransform: 'uppercase', color: 'var(--fg-subtle)' }}>{s.label}</div>
+                </div>
+              ))}
+            </div>
+          ) : null}
 
           <div style={{ marginTop: 28, display: 'flex', gap: 12, alignItems: 'center' }}>
             <a href={`https://${ME.github}`} style={{ textDecoration: 'none' }}>

--- a/data.js
+++ b/data.js
@@ -745,3 +745,13 @@ window.SITE_INDEX = {
     "updated": "2026-06-13"
   }
 };
+
+// ── Hard stats (portfolio hero; reusable). Computed from real lists where
+// possible so they can't go stale; manual where not derivable (flagged). ──
+window.STATS = [
+  { value: '3 mo',                          label: 'zero to launch' },     // manual — fixed achievement, do not auto-age
+  { value: String(window.AGENTS.length),    label: 'agents (1 human)' },   // computed
+  { value: '16',                            label: 'custom skills' },      // manual — no skills list in data.js yet
+  { value: '1,000+',                        label: 'pages ingested' },     // manual — historical
+  { value: String(window.ARTICLES.length),  label: 'field notes' },        // computed
+];


### PR DESCRIPTION
Visible hard-stats strip in the portfolio hero, sourced from a single place.

`window.STATS` in `data.js`:
- **agents (1 human)** and **field notes** are computed from `AGENTS.length` / `ARTICLES.length` — self-correcting, never stale.
- **zero to launch (3 mo)**, **16 custom skills**, **1,000+ pages** are manual, flagged inline (not derivable from page data).

`PortfolioHero` renders the strip from `STATS` (display numerals + mono labels). Replaces the earlier hardcoded `PAGE_PORTFOLIO` copy.