### PR TITLE
Activity feed + commit chart redesign

### DIFF
--- a/components/CommitChart.jsx
+++ b/components/CommitChart.jsx
@@ -1,0 +1,123 @@
+// CommitChart.jsx — portfolio "Live from the Lab": all-time weekly commit volume
+// (violet bars) + cumulative total (gold line), drawn as dependency-free SVG to
+// match the site's hand-rolled graph convention. Honest status + last-activity via
+// LiveBadge (see live-github.jsx).
+//
+// Range: anchored at the first commit and grows rightward — the "nothing before
+// March, look how much since" story. No window/scroll controls (they would scroll
+// past the origin). Data: /stats/commit_activity (trailing 52 weeks; see design
+// doc §7 for the ~Mar-2027 ceiling) + a 1-commit probe for the last-activity time.
+//
+// Colors are applied via inline `style` (CSS vars do NOT resolve in SVG presentation
+// attributes like fill="var(--x)", only in the style property).
+
+const CHART_LEADIN = 3;
+
+function chartMonth(epochSec) { return new Date(epochSec * 1000).toLocaleDateString('en-US', { month: 'short' }); }
+function chartMonthYear(epochSec) { return new Date(epochSec * 1000).toLocaleDateString('en-US', { month: 'short', year: 'numeric' }); }
+
+const CHART_MSG = { padding: '36px 20px', textAlign: 'center', fontFamily: 'var(--font-mono)', fontSize: 11, letterSpacing: '0.2em', color: 'var(--fg-faint)' };
+
+const CommitChart = () => {
+  const repo = (window.ME && window.ME.ghRepo) || 'JeremyMontz/Meta1';
+  const [weeks, setWeeks] = React.useState(null);
+  const [status, setStatus] = React.useState(GH.SYNCING);
+  const [cachedAt, setCachedAt] = React.useState(null);
+  const [lastActivity, setLastActivity] = React.useState(null);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    const base = `https://api.github.com/repos/${repo}`;
+    Promise.all([
+      ghFetch(`${base}/stats/commit_activity`, { retry202: 1 }),
+      ghFetch(`${base}/commits?per_page=1`),
+    ]).then(([s, c]) => {
+      if (cancelled) return;
+      const arr = Array.isArray(s.data) ? s.data : [];
+      const st = ghCombineStatus([s.status, c.status]);
+      setWeeks(arr);
+      setStatus(arr.length === 0 && st === GH.STREAMING ? GH.EMPTY : st);
+      setCachedAt(s.cachedAt || c.cachedAt || null);
+      if (c.data && c.data[0]) setLastActivity(new Date(c.data[0].commit.author.date));
+    });
+    return () => { cancelled = true; };
+  }, [repo]);
+
+  const series = (() => {
+    if (!weeks || !weeks.length) return null;
+    const first = weeks.findIndex((w) => w.total > 0);
+    if (first < 0) return [];
+    const start = Math.max(0, first - CHART_LEADIN);
+    let run = 0;
+    return weeks.slice(start).map((w) => { run += w.total; return { week: w.week, total: w.total, cum: run }; });
+  })();
+
+  const card = (inner) => (
+    <section style={{ padding: '0 40px 40px' }}>
+      <div style={{ border: '1px solid var(--line)', background: 'var(--bg-elev-1)' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', padding: '14px 20px', borderBottom: '1px solid var(--line)' }}>
+          <Eyebrow color="var(--candle)">// COMMIT VOLUME · ALL-TIME</Eyebrow>
+          <LiveBadge status={status} repo={repo} lastActivity={lastActivity} cachedAt={cachedAt} />
+        </div>
+        {inner}
+      </div>
+    </section>
+  );
+
+  if (!series) return card(<div style={CHART_MSG}>// PLOTTING COMMIT HISTORY …</div>);
+  if (series.length === 0) return card(<div style={CHART_MSG}>// NO COMMIT DATA</div>);
+
+  const W = 920, H = 300, mL = 38, mR = 50, mT = 18, mB = 40;
+  const plotW = W - mL - mR, plotH = H - mT - mB;
+  const n = series.length;
+  const maxWk = Math.max(1, ...series.map((d) => d.total));
+  const maxCum = Math.max(1, series[n - 1].cum);
+  const slot = plotW / n;
+  const barW = Math.max(3, Math.min(26, slot * 0.6));
+  const cx = (i) => mL + slot * (i + 0.5);
+  const yBar = (v) => mT + plotH * (1 - v / maxWk);
+  const yCum = (v) => mT + plotH * (1 - v / maxCum);
+  const baseY = mT + plotH;
+  const linePts = series.map((d, i) => `${cx(i).toFixed(1)},${yCum(d.cum).toFixed(1)}`).join(' ');
+  const labelEvery = Math.ceil(n / 8);
+  const totalCharted = series[n - 1].cum;
+  const firstWk = series.find((d) => d.total > 0);
+  const sinceLabel = chartMonthYear(firstWk.week);
+  const txt = (size, fill) => ({ fontFamily: 'var(--font-mono)', fontSize: size + 'px', fill: fill });
+
+  return card(
+    <div style={{ padding: '16px 12px 6px' }}>
+      <svg viewBox={`0 0 ${W} ${H}`} width="100%" role="img"
+           aria-label={`Weekly commits since ${sinceLabel}: violet bars for weekly volume and a gold cumulative line reaching ${totalCharted}.`}
+           style={{ display: 'block' }}>
+        <line x1={mL} y1={baseY} x2={mL + plotW} y2={baseY} style={{ stroke: 'var(--line)' }} strokeWidth="1" />
+        <line x1={mL} y1={yBar(maxWk)} x2={mL + plotW} y2={yBar(maxWk)} style={{ stroke: 'var(--line-soft)', strokeDasharray: '2 4' }} strokeWidth="1" />
+        <text x={mL - 6} y={yBar(maxWk) + 3} textAnchor="end" style={txt(9, 'var(--fg-faint)')}>{maxWk}</text>
+        <text x={mL - 6} y={baseY + 3} textAnchor="end" style={txt(9, 'var(--fg-faint)')}>0</text>
+        {series.map((d, i) => (
+          <rect key={'b' + i} x={cx(i) - barW / 2} y={yBar(d.total)} width={barW} height={Math.max(0, baseY - yBar(d.total))} style={{ fill: 'var(--accent)', opacity: 0.9 }}>
+            <title>{`${chartMonthYear(d.week)} — ${d.total} commits (running ${d.cum})`}</title>
+          </rect>
+        ))}
+        <polyline points={linePts} style={{ fill: 'none', stroke: 'var(--candle)' }} strokeWidth="2" strokeLinejoin="round" strokeLinecap="round" />
+        {series.map((d, i) => (<circle key={'c' + i} cx={cx(i)} cy={yCum(d.cum)} r="2.2" style={{ fill: 'var(--candle)' }} />))}
+        <text x={mL + plotW + 6} y={yCum(maxCum) + 3} textAnchor="start" style={txt(9, 'var(--candle)')}>{maxCum}</text>
+        {series.map((d, i) => (i % labelEvery === 0 ? (
+          <text key={'x' + i} x={cx(i)} y={baseY + 16} textAnchor="middle" style={txt(9, 'var(--fg-faint)')}>{chartMonth(d.week)}</text>
+        ) : null))}
+      </svg>
+
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: 12, padding: '8px 8px 4px' }}>
+        <div style={{ display: 'flex', gap: 18, fontFamily: 'var(--font-mono)', fontSize: 10, letterSpacing: '0.12em', color: 'var(--fg-subtle)' }}>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}><span style={{ width: 16, height: 10, background: 'var(--accent)', display: 'inline-block', borderRadius: 1 }} />WEEKLY</span>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}><span style={{ width: 16, height: 2, background: 'var(--candle)', display: 'inline-block' }} />CUMULATIVE</span>
+        </div>
+        <div style={{ fontFamily: 'var(--font-mono)', fontSize: 10, letterSpacing: '0.12em', color: 'var(--fg-subtle)' }}>
+          <span style={{ color: 'var(--fg)' }}>{totalCharted}</span> COMMITS SINCE {sinceLabel.toUpperCase()}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+window.CommitChart = CommitChart;

--- a/components/LiveActivity.jsx
+++ b/components/LiveActivity.jsx
@@ -1,147 +1,149 @@
-// LiveActivity.jsx — pulls recent commits at page load and renders them
-// as a horizontal "lab pulse" strip.
+// LiveActivity.jsx — the index "done things" stream: commits + merged PRs +
+// closed issues, newest first. Cache-first paint with honest status (see
+// live-github.jsx). No content hygiene by design (KISS); only collapseRepeats
+// folds *consecutive* identical commit messages.
 //
-// Data source: https://api.github.com/repos/<repo>/commits (CORS-safe,
-// no auth required, rate-limited to 60 req/hr per IP). Configure the repo
-// in data.js (ME.ghRepo). The commits API always carries full messages —
-// unlike the events API, whose PushEvent payloads come back with an empty
-// commits array on this repo (#162 root cause, part two; part one was
-// 'JeremyMontz' being an Org, so user-events were always empty).
-//
-// No placeholder fallbacks by design: an unreachable API shows OFFLINE,
-// a quiet stream shows an honest empty state.
-//
-// Each commit becomes one row: date+time, kind, message (first line).
-// Consecutive identical messages collapse into one row with a (+N) count.
+// Kinds:  COMMIT -> accent (violet) · PR MERGED -> ok (green) · ISSUE CLOSED -> info (blue).
+// Filter: opt-in chips, default ALL (the full mixed stream).
+// Depth:  over-fetch 20, show 6, "show more" reveals the rest client-side (no new
+//         calls); plus a "full history on GitHub" link. No pagination.
+// Dedup:  squash-merge twins — a commit carrying a trailing (#NNN) that matches a
+//         shown PR MERGED is hidden ONLY when both kinds are in view; it returns in
+//         a Commits-only filter.
 
-// Map a commit (from /repos/:repo/commits) → our row shape.
-function formatCommit(c) {
-  const d = new Date(c.commit.author.date);
-  const pad = (n) => String(n).padStart(2, '0');
-  const time = `${pad(d.getMonth() + 1)}·${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
-  return { t: time, kind: 'COMMIT', tone: 'accent', msg: c.commit.message.split('\n')[0] };
+const FEED_FETCH = 20;
+const FEED_SHOW  = 6;
+const FEED_KINDS = ['COMMIT', 'PR MERGED', 'ISSUE CLOSED'];
+const KIND_COLOR = { 'COMMIT': 'var(--accent)', 'PR MERGED': 'var(--ok)', 'ISSUE CLOSED': 'var(--info)' };
+
+function feedTime(d) {
+  const x = new Date(d), p = (n) => String(n).padStart(2, '0');
+  return `${p(x.getMonth() + 1)}·${p(x.getDate())} ${p(x.getHours())}:${p(x.getMinutes())}`;
 }
 
-// Collapse consecutive rows with identical messages → "msg (+N)".
+function normCommit(c) {
+  const msg = (c.commit && c.commit.message ? c.commit.message : '').split('\n')[0];
+  const m = msg.match(/\(#(\d+)\)\s*$/);
+  return { ts: new Date(c.commit.author.date), kind: 'COMMIT', msg: msg, url: c.html_url, pr: m ? +m[1] : null };
+}
+function normPR(p) {
+  return { ts: new Date(p.merged_at), kind: 'PR MERGED', msg: p.title, url: p.html_url, num: p.number };
+}
+function normIssue(i) {
+  return { ts: new Date(i.closed_at), kind: 'ISSUE CLOSED', msg: i.title, url: i.html_url, num: i.number };
+}
+
 function collapseRepeats(rows) {
   const out = [];
-  rows.forEach(r => {
+  rows.forEach((r) => {
     const last = out[out.length - 1];
-    if (last && last.baseMsg === r.msg) {
-      last.count += 1;
-    } else {
-      out.push({ ...r, baseMsg: r.msg, count: 1 });
-    }
+    if (last && last.kind === r.kind && last.baseMsg === r.msg) { last.count += 1; }
+    else { out.push({ ...r, baseMsg: r.msg, count: 1 }); }
   });
-  return out.map(r => r.count > 1 ? { ...r, msg: `${r.baseMsg} (+${r.count - 1})` } : r);
+  return out.map((r) => r.count > 1 ? { ...r, msg: `${r.baseMsg} (+${r.count - 1})` } : r);
 }
 
+const FEED_LOAD = { padding: '24px 20px', textAlign: 'center', fontFamily: 'var(--font-mono)', fontSize: 11, letterSpacing: '0.2em', color: 'var(--fg-faint)' };
+const FEED_LINK = { fontFamily: 'var(--font-mono)', fontSize: 10, letterSpacing: '0.16em', textTransform: 'uppercase', color: 'var(--fg-subtle)', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, textDecoration: 'none' };
+
 const LiveActivity = () => {
-  const [state, setState] = React.useState({ status: 'loading', events: [] });
+  const repo = (window.ME && window.ME.ghRepo) || 'JeremyMontz/Meta1';
+  const [pool, setPool] = React.useState([]);
+  const [status, setStatus] = React.useState(GH.SYNCING);
+  const [cachedAt, setCachedAt] = React.useState(null);
+  const [filter, setFilter] = React.useState('ALL');
+  const [expanded, setExpanded] = React.useState(false);
 
   React.useEffect(() => {
-    const repo = (window.ME && window.ME.ghRepo) || 'JeremyMontz/Meta1';
-    const url = `https://api.github.com/repos/${repo}/commits?per_page=10`;
     let cancelled = false;
-
-    fetch(url)
-      .then(r => {
-        if (!r.ok) throw new Error('HTTP ' + r.status);
-        return r.json();
-      })
-      .then(commits => {
-        if (cancelled) return;
-        const rows = collapseRepeats((commits || []).map(formatCommit)).slice(0, 6);
-        if (rows.length > 0) {
-          setState({ status: 'live', events: rows });
-        } else {
-          // Empty repo / no commits — honest empty state.
-          setState({ status: 'empty', events: [] });
-        }
-      })
-      .catch(() => {
-        if (cancelled) return;
-        // API unreachable or rate-limited — say so, show nothing fake.
-        setState({ status: 'offline', events: [] });
-      });
-
+    const base = `https://api.github.com/repos/${repo}`;
+    Promise.all([
+      ghFetch(`${base}/commits?per_page=${FEED_FETCH}`),
+      ghFetch(`${base}/pulls?state=closed&sort=updated&direction=desc&per_page=${FEED_FETCH}`),
+      ghFetch(`${base}/issues?state=closed&sort=updated&direction=desc&per_page=${FEED_FETCH}`),
+    ]).then(([c, p, i]) => {
+      if (cancelled) return;
+      const commits = (Array.isArray(c.data) ? c.data : []).map(normCommit);
+      const prs     = (Array.isArray(p.data) ? p.data : []).filter((x) => x.merged_at).map(normPR);
+      const issues  = (Array.isArray(i.data) ? i.data : []).filter((x) => !x.pull_request && x.closed_at).map(normIssue);
+      const merged  = [...commits, ...prs, ...issues].sort((a, b) => b.ts - a.ts);
+      const st = ghCombineStatus([c.status, p.status, i.status]);
+      setPool(merged);
+      setStatus(merged.length === 0 && st === GH.STREAMING ? GH.EMPTY : st);
+      setCachedAt(c.cachedAt || p.cachedAt || i.cachedAt || null);
+    });
     return () => { cancelled = true; };
-  }, []);
+  }, [repo]);
 
-  const { status, events } = state;
-  const isLoading = status === 'loading';
+  const showBoth = filter === 'ALL';
+  const mergedPRNums = new Set(pool.filter((e) => e.kind === 'PR MERGED').map((e) => e.num));
+  let rows = pool.filter((e) => filter === 'ALL' || e.kind === filter);
+  if (showBoth) rows = rows.filter((e) => !(e.kind === 'COMMIT' && e.pr && mergedPRNums.has(e.pr)));
+  rows = collapseRepeats(rows);
+  const visible = expanded ? rows : rows.slice(0, FEED_SHOW);
+  const lastActivity = pool.length ? pool[0].ts : null;
+  const isSyncing = status === GH.SYNCING;
+
+  const chip = (key, label) => {
+    const active = filter === key;
+    const accent = key === 'ALL' ? 'var(--fg)' : KIND_COLOR[key];
+    const border = key === 'ALL' ? 'var(--line-loud)' : KIND_COLOR[key];
+    return (
+      <button key={key} onClick={() => { setFilter(key); setExpanded(false); }} style={{
+        fontFamily: 'var(--font-mono)', fontSize: 10, letterSpacing: '0.16em', textTransform: 'uppercase',
+        padding: '4px 10px', borderRadius: 2, cursor: 'pointer',
+        border: `1px solid ${active ? border : 'var(--line)'}`,
+        color: active ? accent : 'var(--fg-subtle)',
+        background: active ? 'var(--bg-elev-2)' : 'transparent',
+      }}>{label}</button>
+    );
+  };
 
   return (
     <section style={{ padding: '0 40px 40px' }}>
-      <div style={{
-        border: '1px solid var(--line)', background: 'var(--bg-elev-1)',
-      }}>
-        <div style={{
-          display: 'flex', justifyContent: 'space-between', alignItems: 'center',
-          padding: '14px 20px', borderBottom: '1px solid var(--line)',
-        }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 14 }}>
-            <Eyebrow color="var(--candle)">// RECENT ACTIVITY</Eyebrow>
-          </div>
-          <div style={{
-            display: 'inline-flex', alignItems: 'center', gap: 8,
-            fontFamily: 'var(--font-mono)', fontSize: 10,
-            letterSpacing: '0.22em', textTransform: 'uppercase',
-          }}>
-            {status === 'loading' && (<>
-              <span style={{ color: 'var(--fg-faint)' }}>SYNCING</span>
-              <StatusDot tone="na" />
-            </>)}
-            {status === 'live' && (<>
-              <span style={{ color: 'var(--ok)' }}>STREAMING · {(window.ME && window.ME.ghRepo) || 'JeremyMontz/Meta1'}</span>
-              <span className="pulse-dot" style={{ width: 7, height: 7, borderRadius: '50%', background: 'var(--ok)', color: 'var(--ok)' }} />
-            </>)}
-            {status === 'offline' && (<>
-              <span style={{ color: 'var(--warn)' }}>OFFLINE · GITHUB UNREACHABLE</span>
-              <StatusDot tone="warn" />
-            </>)}
-            {status === 'empty' && (<>
-              <span style={{ color: 'var(--fg-faint)' }}>NO RECENT EVENTS</span>
-              <StatusDot tone="na" />
-            </>)}
-          </div>
+      <div style={{ border: '1px solid var(--line)', background: 'var(--bg-elev-1)' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', padding: '14px 20px', borderBottom: '1px solid var(--line)' }}>
+          <Eyebrow color="var(--candle)">// RECENT ACTIVITY</Eyebrow>
+          <LiveBadge status={status} repo={repo} lastActivity={lastActivity} cachedAt={cachedAt} />
         </div>
 
-        {isLoading ? (
-          <div style={{
-            padding: '24px 20px', textAlign: 'center',
-            fontFamily: 'var(--font-mono)', fontSize: 11,
-            letterSpacing: '0.22em', color: 'var(--fg-faint)',
-          }}>// FETCHING EVENTS …</div>
-        ) : events.length === 0 ? (
-          <div style={{
-            padding: '24px 20px', textAlign: 'center',
-            fontFamily: 'var(--font-mono)', fontSize: 11,
-            letterSpacing: '0.18em', color: 'var(--fg-faint)',
-          }}>// QUIET CYCLE · NO RECENT COMMITS</div>
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', padding: '12px 20px', borderBottom: '1px solid var(--line-soft)' }}>
+          {chip('ALL', 'All')}
+          {chip('COMMIT', 'Commit')}
+          {chip('PR MERGED', 'PR merged')}
+          {chip('ISSUE CLOSED', 'Issue closed')}
+        </div>
+
+        {isSyncing ? (
+          <div style={FEED_LOAD}>// FETCHING EVENTS …</div>
+        ) : visible.length === 0 ? (
+          <div style={FEED_LOAD}>// QUIET CYCLE · NOTHING TO SHOW HERE</div>
         ) : (
           <div>
-            {events.map((e, i) => (
-              <div key={i} style={{
-                display: 'grid', gridTemplateColumns: '105px 90px 1fr',
-                gap: 14, padding: '12px 20px',
-                borderBottom: i < events.length - 1 ? '1px solid var(--line-soft)' : 'none',
-                alignItems: 'baseline',
-                fontFamily: 'var(--font-mono)', fontSize: 12,
+            {visible.map((e, idx) => (
+              <a key={idx} href={e.url || '#'} target="_blank" rel="noopener noreferrer" style={{
+                display: 'grid', gridTemplateColumns: '96px 104px 1fr', gap: 12, padding: '12px 20px',
+                borderBottom: '1px solid var(--line-soft)', alignItems: 'baseline',
+                fontFamily: 'var(--font-mono)', fontSize: 12, textDecoration: 'none',
               }}>
-                <span style={{ color: 'var(--candle)', letterSpacing: '0.12em' }}>{e.t}</span>
-                <span style={{
-                  letterSpacing: '0.14em',
-                  color: e.tone === 'accent' ? 'var(--accent)' :
-                         e.tone === 'warn'   ? 'var(--warn)'   :
-                         e.tone === 'ok'     ? 'var(--ok)'     :
-                                                'var(--info)',
-                }}>{e.kind}</span>
+                <span style={{ color: 'var(--candle)', letterSpacing: '0.1em' }}>{feedTime(e.ts)}</span>
+                <span style={{ letterSpacing: '0.12em', color: KIND_COLOR[e.kind] }}>{e.kind}</span>
                 <span style={{ color: 'var(--fg-muted)', lineHeight: 1.5 }}>{e.msg}</span>
-              </div>
+              </a>
             ))}
           </div>
         )}
+
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '12px 20px', borderTop: '1px solid var(--line)' }}>
+          <div>
+            {!expanded && rows.length > FEED_SHOW ? (
+              <button onClick={() => setExpanded(true)} style={FEED_LINK}>SHOW MORE ↓ ({rows.length - FEED_SHOW})</button>
+            ) : expanded && rows.length > FEED_SHOW ? (
+              <button onClick={() => setExpanded(false)} style={FEED_LINK}>SHOW LESS ↑</button>
+            ) : (<span />)}
+          </div>
+          <a href={`https://github.com/${repo}/commits`} target="_blank" rel="noopener noreferrer" style={FEED_LINK}>FULL HISTORY ON GITHUB ↗</a>
+        </div>
       </div>
     </section>
   );

--- a/components/PortfolioMain.jsx
+++ b/components/PortfolioMain.jsx
@@ -130,8 +130,8 @@ const WhatItProves = () => {
 };
 
 // ── 02 · LIVE FROM THE LAB ──────────────────────────────────────────────────
-// Section header + the real GitHub commit feed (components/LiveActivity.jsx,
-// lifted from the homepage). The feed is the receipt that backs the claim above.
+// Section header + the all-time commit-volume chart (components/CommitChart.jsx,
+// dependency-free SVG). The chart is the receipt that backs the claim above.
 const LiveFromLab = () => {
   const s = PG.live || {};
   return (
@@ -141,7 +141,7 @@ const LiveFromLab = () => {
         <h2 style={{ marginTop: 8, marginBottom: 8 }}>{s.heading}</h2>
         <p style={{ maxWidth: 560 }}>{s.sub}</p>
       </div>
-      <LiveActivity />
+      <CommitChart />
     </>
   );
 };

--- a/components/live-github.jsx
+++ b/components/live-github.jsx
@@ -1,0 +1,111 @@
+// live-github.jsx — shared GitHub fetch + cache + honest status + LiveBadge.
+// Loaded via <script type="text/babel"> AFTER Primitives.jsx and BEFORE
+// LiveActivity.jsx / CommitChart.jsx.
+//
+// Honesty model (the brand requirement):
+//   STREAMING (green pulse) — a live fetch succeeded THIS load (all sources fresh).
+//   CACHED    (amber)       — showing stored data: pre-refresh paint, a refresh that
+//                             fell back to cache, or a mixed fresh/stale set.
+//   OFFLINE   (red)         — no cache AND the fetch failed.
+//   EMPTY     (neutral)     — fetch succeeded, zero events.
+//   SYNCING   (neutral)     — no cache yet, first fetch in flight.
+//
+// Cache: sessionStorage, 10-min TTL, keyed on the request URL.
+
+const GH_TTL = 10 * 60 * 1000;
+const GH_CACHE_PREFIX = 'ghcache:';
+
+const GH = { SYNCING: 'syncing', STREAMING: 'streaming', CACHED: 'cached', OFFLINE: 'offline', EMPTY: 'empty' };
+
+function ghReadCache(url) {
+  try {
+    const raw = sessionStorage.getItem(GH_CACHE_PREFIX + url);
+    if (!raw) return null;
+    const o = JSON.parse(raw);
+    return (o && typeof o.ts === 'number') ? o : null;
+  } catch (e) { return null; }
+}
+
+function ghWriteCache(url, data) {
+  try { sessionStorage.setItem(GH_CACHE_PREFIX + url, JSON.stringify({ ts: Date.now(), data })); }
+  catch (e) { /* quota / private mode — skip */ }
+}
+
+// Fetch JSON, cache on success, fall back to cache on failure.
+// opts: { accept, retry202 }. Resolves { data, fresh, fromCache, status, cachedAt? }.
+function ghFetch(url, opts) {
+  opts = opts || {};
+  const headers = opts.accept ? { Accept: opts.accept } : {};
+  const cached = ghReadCache(url);
+
+  const attempt = (left) => fetch(url, { headers }).then((r) => {
+    if (r.status === 202) {
+      if (left > 0) return new Promise((res) => setTimeout(res, 1500)).then(() => attempt(left - 1));
+      const e = new Error('202'); e.code = 202; throw e;
+    }
+    if (!r.ok) throw new Error('HTTP ' + r.status);
+    return r.json().then((data) => {
+      ghWriteCache(url, data);
+      return { data: data, fresh: true, fromCache: false, status: GH.STREAMING };
+    });
+  });
+
+  return attempt(opts.retry202 || 0).catch(() => {
+    if (cached) return { data: cached.data, fresh: false, fromCache: true, status: GH.CACHED, cachedAt: cached.ts };
+    return { data: null, fresh: false, fromCache: false, status: GH.OFFLINE };
+  });
+}
+
+function ghCombineStatus(parts) {
+  if (!parts || !parts.length) return GH.OFFLINE;
+  if (parts.every((p) => p === GH.STREAMING)) return GH.STREAMING;
+  if (parts.some((p) => p === GH.STREAMING || p === GH.CACHED)) return GH.CACHED;
+  return GH.OFFLINE;
+}
+
+function ghAgo(when) {
+  if (!when) return '';
+  const t = (when instanceof Date) ? when.getTime() : when;
+  const m = Math.floor((Date.now() - t) / 60000);
+  if (m < 1) return 'just now';
+  if (m < 60) return m + 'm ago';
+  const h = Math.floor(m / 60);
+  if (h < 24) return h + 'h ago';
+  return Math.floor(h / 24) + 'd ago';
+}
+
+const LiveBadge = ({ status, repo, lastActivity, cachedAt }) => {
+  const r = repo || 'JeremyMontz/Meta1';
+  const row = { display: 'inline-flex', alignItems: 'center', gap: 8, fontFamily: 'var(--font-mono)', fontSize: 10, letterSpacing: '0.22em', textTransform: 'uppercase' };
+
+  let label, color, dot;
+  if (status === GH.STREAMING) {
+    label = 'STREAMING · ' + r; color = 'var(--ok)';
+    dot = <span className="pulse-dot" style={{ width: 7, height: 7, borderRadius: '50%', background: 'var(--ok)', color: 'var(--ok)' }} />;
+  } else if (status === GH.CACHED) {
+    label = 'CACHED' + (cachedAt ? ' · ' + ghAgo(cachedAt) : ''); color = 'var(--warn)';
+    dot = <StatusDot tone="warn" />;
+  } else if (status === GH.OFFLINE) {
+    label = 'OFFLINE · GITHUB UNREACHABLE'; color = 'var(--err)';
+    dot = <StatusDot tone="err" />;
+  } else if (status === GH.EMPTY) {
+    label = 'NO RECENT EVENTS'; color = 'var(--fg-faint)';
+    dot = <StatusDot tone="na" />;
+  } else {
+    label = 'SYNCING'; color = 'var(--fg-faint)';
+    dot = <StatusDot tone="na" />;
+  }
+
+  return (
+    <span style={{ display: 'inline-flex', flexDirection: 'column', alignItems: 'flex-end', gap: 3 }}>
+      <span style={row}><span style={{ color }}>{label}</span>{dot}</span>
+      {lastActivity ? (
+        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 9.5, letterSpacing: '0.16em', textTransform: 'uppercase', color: 'var(--fg-faint)' }}>
+          LAST ACTIVITY · {ghAgo(lastActivity)}
+        </span>
+      ) : null}
+    </span>
+  );
+};
+
+Object.assign(window, { GH, GH_TTL, ghFetch, ghCombineStatus, ghAgo, LiveBadge });

--- a/index.html
+++ b/index.html
@@ -155,6 +155,7 @@ window.PAGE_HOME = {
 <script type="text/babel" src="components/AgentGraph.jsx"></script>
 
 <!-- Live activity (fetches real GitHub events) -->
+<script type="text/babel" src="components/live-github.jsx"></script>
 <script type="text/babel" src="components/LiveActivity.jsx"></script>
 
 <!-- Page composition -->

--- a/portfolio.html
+++ b/portfolio.html
@@ -88,8 +88,8 @@ window.PAGE_PORTFOLIO = {
   // ── 02 · Live from the Lab (real GitHub commit feed via LiveActivity.jsx) ──
   live: {
     eyebrow: '02 · LIVE FROM GITHUB',
-    heading: 'The lab, the repo, the pulse of development.',
-    sub: "This is the actual commit stream of the system you're reading — pulled from GitHub at page load.",
+    heading: 'Commit volume, since the first push.',
+    sub: "Every week of work on the system you're reading — pulled live from GitHub, anchored at the first commit.",
   },
 
   // ── 03 · The Work (project matrix; rows come from data.js PORTFOLIO) ──
@@ -110,7 +110,8 @@ window.PAGE_PORTFOLIO = {
 <script type="text/babel" src="components/Wordmark.jsx"></script>
 <script type="text/babel" src="components/Primitives.jsx"></script>
 <script type="text/babel" src="components/HomeShell.jsx"></script>
-<script type="text/babel" src="components/LiveActivity.jsx"></script>
+<script type="text/babel" src="components/live-github.jsx"></script>
+<script type="text/babel" src="components/CommitChart.jsx"></script>
 <script type="text/babel" src="components/CompetencyGraph.jsx"></script>
 <script type="text/babel" src="components/PortfolioMain.jsx"></script>
 


### PR DESCRIPTION
## What
Reworks the GitHub activity surface on **index** and **portfolio**, and makes both resilient to the unauthenticated 60 req/hr cap.

### Shared (`components/live-github.jsx`)
- `sessionStorage` cache, 10-min TTL, cache-first paint then fetch-update.
- Honest status: **STREAMING** (green pulse) only on a true live fetch this load; **CACHED** (amber, with age) when serving stored data; **OFFLINE** (red) only with no cache + failed fetch.
- `LiveBadge` (status pill + "last activity" timestamp) shared by both pages.

### Index feed (`LiveActivity.jsx`)
- Now a unified "done things" stream: **COMMIT** (violet) + **PR MERGED** (green) + **ISSUE CLOSED** (blue).
- Opt-in filter chips, default **all** (preserves the unfiltered feel).
- Bounded reveal (over-fetch 20, show 6, "show more" with zero new calls) + "full history on GitHub" link. No pagination.
- Filter-aware squash-merge dedup keyed on trailing `(#NNN)`: a commit twin hides only when its PR is also shown; it returns in the Commits-only filter.
- No content hygiene (KISS) — only `collapseRepeats` for consecutive dupes.

### Portfolio chart (`CommitChart.jsx`)
- Replaces the raw feed with an all-time **weekly bars (violet) + cumulative line (gold)** SVG, anchored at the first commit (the "wall"). Dependency-free, matching the site’s hand-rolled graph convention.
- 202 cold-start retry on the stats endpoint; live status + last-activity above the chart.

### Verification
- All three JSX files transform cleanly under Babel 7.29.0 (the version the site loads).
- Data pipeline exercised against live API: dedup removed 12 PR-twin commits in All view (return in Commits-only); issue filter dropped 15 PRs to keep 5 real closed issues; chart series `0,0,0,28,29,…,18` → 459 cumulative since Mar 2026.

### Follow-up (not in this PR)
- `/stats/commit_activity` only reaches back 52 weeks; the March origin falls out of range ~Mar 2027. Move to a durable weekly-commit source before then.

Design doc: `projects/meta1/meta1/design/activity-feed-and-chart-redesign.md`