### PR TITLE
Commit chart: baked snapshot + patient live upgrade

### DIFF
--- a/components/CommitChart.jsx
+++ b/components/CommitChart.jsx
@@ -1,17 +1,20 @@
 // CommitChart.jsx — portfolio "Live from the Lab": all-time weekly commit volume
-// (violet bars) + cumulative total (gold line), drawn as dependency-free SVG to
-// match the site's hand-rolled graph convention. Honest status + last-activity via
-// LiveBadge (see live-github.jsx).
+// (violet bars) + cumulative total (gold line), dependency-free SVG.
 //
-// Range: anchored at the first commit and grows rightward — the "nothing before
-// March, look how much since" story. No window/scroll controls (they would scroll
-// past the origin). Data: /stats/commit_activity (trailing 52 weeks; see design
-// doc §7 for the ~Mar-2027 ceiling) + a 1-commit probe for the last-activity time.
+// Data model (no browser cache by design):
+//   1. A baked snapshot (window.COMMIT_WEEKS, dated COMMIT_WEEKS_ASOF) renders
+//      instantly so EVERY visitor — first-timers included — sees the chart at once,
+//      labeled honestly "SNAPSHOT · <date>".
+//   2. /stats/commit_activity (which returns 202 while GitHub recomputes after each
+//      push) is polled patiently in the background; the moment it returns 200, the
+//      chart upgrades to fresh data + green STREAMING.
+//   If the live endpoint never answers during the visit, the dated snapshot stays —
+//   graceful and honest, never a blank "warming up."
 //
-// Colors are applied via inline `style` (CSS vars do NOT resolve in SVG presentation
-// attributes like fill="var(--x)", only in the style property).
+// Colors via inline style (CSS vars don't resolve in SVG presentation attributes).
 
 const CHART_LEADIN = 3;
+const CHART_MAX_POLLS = 12;   // ~60s of patient background retries
 
 function chartMonth(epochSec) { return new Date(epochSec * 1000).toLocaleDateString('en-US', { month: 'short' }); }
 function chartMonthYear(epochSec) { return new Date(epochSec * 1000).toLocaleDateString('en-US', { month: 'short', year: 'numeric' }); }
@@ -20,34 +23,43 @@ const CHART_MSG = { padding: '36px 20px', textAlign: 'center', fontFamily: 'var(
 
 const CommitChart = () => {
   const repo = (window.ME && window.ME.ghRepo) || 'JeremyMontz/Meta1';
-  const [weeks, setWeeks] = React.useState(null);
-  const [status, setStatus] = React.useState(GH.SYNCING);
-  const [cachedAt, setCachedAt] = React.useState(null);
-  const [lastActivity, setLastActivity] = React.useState(null);
+  const snapshot = (typeof window !== 'undefined' && window.COMMIT_WEEKS) || [];
+  const asOfRaw = (typeof window !== 'undefined' && window.COMMIT_WEEKS_ASOF) || '';
+  const snapshotDate = asOfRaw ? new Date(asOfRaw + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) : '';
 
-  const triesRef = React.useRef(0);
+  const [weeks, setWeeks] = React.useState(snapshot);
+  const [status, setStatus] = React.useState(snapshot.length ? GH.SNAPSHOT : GH.SYNCING);
+  const [lastActivity, setLastActivity] = React.useState(null);
+  const pollsRef = React.useRef(0);
+
   React.useEffect(() => {
     let cancelled = false;
-    triesRef.current = 0;
+    pollsRef.current = 0;
     const base = `https://api.github.com/repos/${repo}`;
-    // Last-activity timestamp: a cheap commits probe, independent of chart data.
-    ghFetch(`${base}/commits?per_page=1`).then((c) => {
-      if (!cancelled && c.data && c.data[0]) setLastActivity(new Date(c.data[0].commit.author.date));
-    });
-    // Chart status is driven by the stats endpoint ALONE. /stats/commit_activity
-    // returns 202 while GitHub computes; ghFetch retries that internally and we
-    // self-heal with a few delayed passes so a cold cache fills without a reload.
-    const load = () => ghFetch(`${base}/stats/commit_activity`, { retry202: 4 }).then((s) => {
-      if (cancelled) return;
-      const arr = Array.isArray(s.data) ? s.data : [];
-      setCachedAt(s.cachedAt || null);
-      if (arr.length > 0) { setWeeks(arr); setStatus(s.status === GH.CACHED ? GH.CACHED : GH.STREAMING); return; }
-      if (s.status === GH.CACHED) { setWeeks(arr); setStatus(GH.CACHED); return; }
-      triesRef.current += 1;
-      if (triesRef.current < 3) { setStatus(GH.SYNCING); setTimeout(() => { if (!cancelled) load(); }, 4000); }
-      else { setWeeks([]); setStatus(s.status === GH.OFFLINE ? GH.OFFLINE : GH.EMPTY); }
-    });
-    load();
+
+    // Last-activity timestamp — cheap probe, independent of chart data.
+    fetch(`${base}/commits?per_page=1`)
+      .then((r) => r.ok ? r.json() : null)
+      .then((d) => { if (!cancelled && d && d[0]) setLastActivity(new Date(d[0].commit.author.date)); })
+      .catch(() => {});
+
+    // Patiently poll the live stats endpoint; upgrade to STREAMING on a real 200.
+    const poll = () => fetch(`${base}/stats/commit_activity`)
+      .then((r) => { if (r.status === 200) return r.json(); throw new Error(String(r.status)); })
+      .then((arr) => {
+        if (cancelled) return;
+        if (Array.isArray(arr) && arr.length) { setWeeks(arr); setStatus(GH.STREAMING); }
+        else { again(); }
+      })
+      .catch(() => { if (!cancelled) again(); });
+
+    const again = () => {
+      pollsRef.current += 1;
+      if (pollsRef.current < CHART_MAX_POLLS && !cancelled) setTimeout(poll, 5000);
+      // else: keep the dated snapshot (status unchanged).
+    };
+
+    poll();
     return () => { cancelled = true; };
   }, [repo]);
 
@@ -65,7 +77,7 @@ const CommitChart = () => {
       <div style={{ border: '1px solid var(--line)', background: 'var(--bg-elev-1)' }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', padding: '14px 20px', borderBottom: '1px solid var(--line)' }}>
           <Eyebrow color="var(--candle)">// COMMIT VOLUME · ALL-TIME</Eyebrow>
-          <LiveBadge status={status} repo={repo} lastActivity={lastActivity} cachedAt={cachedAt} />
+          <LiveBadge status={status} repo={repo} lastActivity={lastActivity} snapshotDate={snapshotDate} />
         </div>
         {inner}
       </div>

--- a/components/live-github.jsx
+++ b/components/live-github.jsx
@@ -15,7 +15,7 @@
 const GH_TTL = 10 * 60 * 1000;
 const GH_CACHE_PREFIX = 'ghcache:';
 
-const GH = { SYNCING: 'syncing', STREAMING: 'streaming', CACHED: 'cached', OFFLINE: 'offline', EMPTY: 'empty' };
+const GH = { SYNCING: 'syncing', STREAMING: 'streaming', CACHED: 'cached', OFFLINE: 'offline', EMPTY: 'empty', SNAPSHOT: 'snapshot' };
 
 function ghReadCache(url) {
   try {
@@ -74,7 +74,7 @@ function ghAgo(when) {
   return Math.floor(h / 24) + 'd ago';
 }
 
-const LiveBadge = ({ status, repo, lastActivity, cachedAt }) => {
+const LiveBadge = ({ status, repo, lastActivity, cachedAt, snapshotDate }) => {
   const r = repo || 'JeremyMontz/Meta1';
   const row = { display: 'inline-flex', alignItems: 'center', gap: 8, fontFamily: 'var(--font-mono)', fontSize: 10, letterSpacing: '0.22em', textTransform: 'uppercase' };
 
@@ -84,6 +84,9 @@ const LiveBadge = ({ status, repo, lastActivity, cachedAt }) => {
     dot = <span className="pulse-dot" style={{ width: 7, height: 7, borderRadius: '50%', background: 'var(--ok)', color: 'var(--ok)' }} />;
   } else if (status === GH.CACHED) {
     label = 'CACHED' + (cachedAt ? ' · ' + ghAgo(cachedAt) : ''); color = 'var(--warn)';
+    dot = <StatusDot tone="warn" />;
+  } else if (status === GH.SNAPSHOT) {
+    label = 'SNAPSHOT' + (snapshotDate ? ' · ' + snapshotDate : ''); color = 'var(--warn)';
     dot = <StatusDot tone="warn" />;
   } else if (status === GH.OFFLINE) {
     label = 'OFFLINE · GITHUB UNREACHABLE'; color = 'var(--err)';

--- a/data.js
+++ b/data.js
@@ -38,6 +38,31 @@ window.SITE = {
   version: 'v3.3',
   status:  'LIVE',
 };
+
+// ─── COMMIT_WEEKS · baked snapshot for the portfolio commit chart ──────
+// Always-present fallback so every visitor (even first-time) sees the chart
+// instantly while /stats/commit_activity (which 202s during GitHub recompute)
+// catches up; the live endpoint upgrades it to STREAMING. Refresh: see issue #260.
+// Static early-history is fine for an extended period. Weekly Sunday buckets, UTC.
+window.COMMIT_WEEKS_ASOF = '2026-06-16';
+window.COMMIT_WEEKS = [
+  { week: 1772323200, total: 0 },
+  { week: 1772928000, total: 0 },
+  { week: 1773532800, total: 0 },
+  { week: 1774137600, total: 28 },
+  { week: 1774742400, total: 29 },
+  { week: 1775347200, total: 15 },
+  { week: 1775952000, total: 7 },
+  { week: 1776556800, total: 21 },
+  { week: 1777161600, total: 7 },
+  { week: 1777766400, total: 7 },
+  { week: 1778371200, total: 83 },
+  { week: 1778976000, total: 7 },
+  { week: 1779580800, total: 55 },
+  { week: 1780185600, total: 97 },
+  { week: 1780790400, total: 85 },
+  { week: 1781395200, total: 19 }
+];
 // ─── ORGANS · the body-part graph pages ───────────────────────────────────
 // Single source of truth for the graph-section subnav. The shared
 // <GraphSubnav active="..." /> component (in components/GraphSubnav.jsx)

--- a/portfolio.html
+++ b/portfolio.html
@@ -59,7 +59,7 @@
 
 <div id="root"></div>
 
-<script src="data.js?v=3.5"></script>
+<script src="data.js?v=3.6"></script>
 
 <!-- PAGE_PORTFOLIO · page-specific prose for portfolio.html (the #186 PAGE_* pattern).
      Edit copy here; facts/lists live in data.js (ME, SPEC, PORTFOLIO). -->


### PR DESCRIPTION
Follow-up to #256 / #259. Implements the baked-snapshot model we discussed for the flaky `/stats/commit_activity` endpoint.

### The problem
`/stats/commit_activity` is the only GitHub endpoint that returns **202 (recomputing)** — it does so after every push, and can stay that way for a while. The chart had nothing to show first-time visitors during that window, and froze on a stale CACHED.

### The fix — a "server-side cache" baked into the site
- **`data.js` `COMMIT_WEEKS`**: a static weekly snapshot (dated `COMMIT_WEEKS_ASOF`) ships with the site, so **every** visitor — first-timers included — sees the chart instantly, labeled honestly **`SNAPSHOT · Jun 16`**.
- **`CommitChart`** renders the snapshot immediately, then **patiently polls** `/stats/commit_activity` (~12 tries over ~60s) and upgrades to fresh data + green **`STREAMING`** the moment it returns 200. If it never answers during the visit, the dated snapshot simply stays — graceful, honest, no blank "warming up."
- **No browser cache for the chart** — the baked snapshot replaces it. (The index feed keeps its sessionStorage cache for rate-limit resilience.)

### Notes
- Snapshot refresh is tracked in #260 (static early-history is fine for an extended period). A baked snapshot also preserves the March origin permanently, which supersedes the historical concern in #258.
- Both JSX files transform cleanly under Babel 7.29.0; `data.js` parses as plain JS; snapshot weeks verified as Sunday buckets Mar 1 → Jun 14.