### PR TITLE
Tier 0 mobile pass (#163): TopNav stack/wrap + overflow-x guard

### DIFF
--- a/components/HomeShell.jsx
+++ b/components/HomeShell.jsx
@@ -77,7 +77,7 @@ const Mascot = ({ size = 96, color }) => (
 
 // TopNav — shared chrome across home + portfolio pages.
 const TopNav = ({ active }) => (
-  <div style={{
+  <div className="topnav" style={{
     display: 'flex', justifyContent: 'space-between', alignItems: 'center',
     padding: '22px 40px', borderBottom: '1px solid var(--line)',
     gap: 32,
@@ -85,7 +85,7 @@ const TopNav = ({ active }) => (
     <div style={{ flexShrink: 0 }}>
       <Wordmark size={26} tick={false} />
     </div>
-    <nav style={{
+    <nav className="topnav-links" style={{
       display: 'flex', gap: 26, flex: 1, justifyContent: 'center',
       fontFamily: 'var(--font-mono)', fontSize: 11,
       letterSpacing: '0.18em', textTransform: 'uppercase',

--- a/design-system/colors_and_type.css
+++ b/design-system/colors_and_type.css
@@ -470,3 +470,20 @@ p, .t-body {
   outline: 2px solid var(--focus);
   outline-offset: 2px;
 }
+
+/* ============================================================
+ * Mobile responsiveness pass (#163)
+ * ============================================================ */
+
+/* Site-wide guard against stray horizontal overflow on small screens.
+ * Stops pages drifting sideways; real overflow is still fixed at source
+ * on the priority pages. Watch position:sticky if anything misbehaves. */
+html, body { overflow-x: hidden; max-width: 100%; }
+
+/* Shared TopNav (HomeShell.jsx) is inline-styled, so these mobile
+ * overrides need !important to win over the element style attribute.
+ * Stack the wordmark over a centered, wrapping row of links. */
+@media (max-width: 720px) {
+  .topnav { flex-direction: column !important; gap: 14px !important; padding: 16px 20px !important; }
+  .topnav-links { flex: 0 1 auto !important; flex-wrap: wrap !important; justify-content: center !important; gap: 16px !important; row-gap: 10px !important; }
+}


### PR DESCRIPTION
**Tier 0 of the mobile-responsiveness pass (#163).** Shared, independently shippable; repairs the nav across all ~34 shared-chrome pages before any priority-page work.

## Changes
- **TopNav stack/wrap (the headline #163 bug).** The shared TopNav was a fixed nowrap flex row with no mobile treatment — on phones the links overflowed and were unreachable. Added `.topnav`/`.topnav-links` classes; at `<=720px` the wordmark stacks over a centered, wrapping link row. All five links stay visible and tappable.
- **Site-wide overflow-x guard.** `html, body { overflow-x: hidden; max-width: 100% }` in the shared design system, stopping stray sideways drift many pages showed on mobile. Real overflow is still fixed at source on index/portfolio in later tiers.

## Notes
- TopNav mobile rules use `!important` because the component is inline-styled (inline styles outrank external CSS).
- **fn-board: no change** — assessment flagged `width:384px`, but it's already clamped via `max-width:calc(100vw-24px)` plus a 720px override. False positive, corrected.

## Testing
Assessed structurally (Chrome here is locked to a 1920px viewport). Needs a quick device check on Safari: all nav links reachable, no horizontal drift, nothing important clipped by the overflow guard.

Design note: `projects/meta1/meta1/design/mobile-pass-163.md`.