### PR TITLE
Tier 1 mobile pass (#163): index + portfolio graph fallback + layout fixes

### DIFF
--- a/components/CompetencyGraph.jsx
+++ b/components/CompetencyGraph.jsx
@@ -44,13 +44,13 @@ const CompetencyGraph = () => {
   const mono = 'var(--font-mono)';
 
   return (
-    <div style={{
+    <div className="graph-layout" style={{
       marginTop: 24,
       display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) 360px',
       gap: 20, alignItems: 'stretch',
     }}>
       {/* ── Graph (landscape, fills the column) ── */}
-      <div style={{
+      <div className="graph-box" style={{
         border: '1px solid var(--line)', background: 'var(--bg-elev-1)', padding: 12,
         height: CG_HEIGHT, display: 'flex', alignItems: 'center', justifyContent: 'center',
       }}>
@@ -85,7 +85,7 @@ const CompetencyGraph = () => {
       </div>
 
       {/* ── Inspector (fixed height; evidence scrolls inside) ── */}
-      <div style={{
+      <div className="graph-inspector" style={{
         border: '1px solid var(--line)', borderLeft: '3px solid var(--accent)',
         background: 'var(--bg-elev-1)', padding: 18,
         height: CG_HEIGHT, display: 'flex', flexDirection: 'column', boxSizing: 'border-box',

--- a/components/HomeMain.jsx
+++ b/components/HomeMain.jsx
@@ -82,7 +82,7 @@ const HomeMain = () => {
           <GraphLegend agents={liveAgents} fetchStatus={fetchStatus} />
         </div>
 
-        <div style={{
+        <div className="graph-layout" style={{
           display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) 400px',
           gap: 20, alignItems: 'stretch',
         }}>
@@ -90,10 +90,13 @@ const HomeMain = () => {
           {/* height:0 + minHeight:100% — the inspector adopts the graph's row
               height without contributing its own, so the graph never resizes
               when inspector content changes (the old hover-jitter bug). */}
-          <div style={{ height: 0, minHeight: '100%' }}>
+          <div className="graph-inspector" style={{ height: 0, minHeight: '100%' }}>
             <Inspector hovered={hovered} agentData={inspectorData} agents={liveAgents} fetchStatus={fetchStatus} />
           </div>
         </div>
+        <p className="graph-caption" style={{ fontFamily: 'var(--font-mono)', fontSize: 11, letterSpacing: '0.1em', color: 'var(--fg-faint)', marginTop: 14, textAlign: 'center', textTransform: 'uppercase' }}>
+          &#9656; Interactive node graph &mdash; explore on desktop
+        </p>
       </section>
 
       <Divider label="// 02 · UNDER THE MICROSCOPE" tone="candle" />

--- a/components/PortfolioMain.jsx
+++ b/components/PortfolioMain.jsx
@@ -28,7 +28,7 @@ const PortfolioHero = () => {
   const body = h.body || [];
   return (
     <div style={{ padding: '64px 40px 56px' }}>
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 360px', gap: 56, alignItems: 'flex-end' }}>
+      <div className="portfolio-hero" style={{ display: 'grid', gridTemplateColumns: '1fr 360px', gap: 56, alignItems: 'flex-end' }}>
         <div>
           <Eyebrow color="var(--candle)">// {h.eyebrow}</Eyebrow>
 
@@ -125,6 +125,9 @@ const WhatItProves = () => {
         <p style={{ maxWidth: 560 }}>{s.sub}</p>
       </div>
       <CompetencyGraph />
+      <p className="graph-caption" style={{ fontFamily: 'var(--font-mono)', fontSize: 11, letterSpacing: '0.1em', color: 'var(--fg-faint)', marginTop: 14, textAlign: 'center', textTransform: 'uppercase' }}>
+        &#9656; Interactive competency graph &mdash; explore on desktop
+      </p>
     </section>
   );
 };
@@ -175,7 +178,7 @@ const PortfolioMatrix = () => {
 const ProjectRow = ({ p, first, last }) => {
   const live = p.tone !== 'na';
   return (
-    <a href={p.href} style={{
+    <a className="project-row" href={p.href} style={{
       display: 'grid', gridTemplateColumns: '80px 1fr 320px',
       gap: 32, padding: '36px 0',
       borderTop: '1px solid var(--line)',

--- a/design-system/colors_and_type.css
+++ b/design-system/colors_and_type.css
@@ -487,3 +487,21 @@ html, body { overflow-x: hidden; max-width: 100%; }
   .topnav { flex-direction: column !important; gap: 14px !important; padding: 16px 20px !important; }
   .topnav-links { flex: 0 1 auto !important; flex-wrap: wrap !important; justify-content: center !important; gap: 16px !important; row-gap: 10px !important; }
 }
+
+/* ---- Tier 1: priority-page layout fixes (#163) ---- */
+/* Graph + inspector blocks (index AgentGraph via HomeMain, portfolio
+   CompetencyGraph) share .graph-layout / .graph-inspector. On mobile,
+   collapse to one column and drop the inspector; the SVG scales full-width
+   and reads as a static labeled graph. .graph-caption explains the loss. */
+.graph-caption { display: none; }
+@media (max-width: 720px) {
+  .graph-layout { grid-template-columns: 1fr !important; }
+  .graph-inspector { display: none !important; }
+  .graph-caption { display: block !important; }
+  .graph-box { height: auto !important; aspect-ratio: 820 / 400 !important; }
+  /* Portfolio: stack the hero and project rows to full width — removes the
+     fixed 360px/320px side tracks that crushed content into a center band
+     and forced row 01 to overflow. */
+  .portfolio-hero { grid-template-columns: 1fr !important; gap: 28px !important; }
+  .project-row { grid-template-columns: 1fr !important; gap: 16px !important; padding: 24px 0 !important; }
+}

--- a/design-system/colors_and_type.css
+++ b/design-system/colors_and_type.css
@@ -505,3 +505,11 @@ html, body { overflow-x: hidden; max-width: 100%; }
   .portfolio-hero { grid-template-columns: 1fr !important; gap: 28px !important; }
   .project-row { grid-template-columns: 1fr !important; gap: 16px !important; padding: 24px 0 !important; }
 }
+
+/* ---- Organ subnav (GraphSubnav .graph-subnav): wrap on mobile (#163) ----
+   Its base rules live in each organ page's inline <style>; this shared
+   override (with !important) reaches them all. Without it the organ links
+   overflow off-screen and, under the overflow-x guard, become unreachable. */
+@media (max-width: 720px) {
+  .graph-subnav { flex-wrap: wrap !important; gap: 12px 16px !important; padding: 10px 20px !important; }
+}


### PR DESCRIPTION
**Tier 1 of #163** — fixes the two priority pages now that the Tier 0 overflow guard is clipping (not scrolling) their real overflow.

## index.html
- Graph + inspector grid (`minmax(0,1fr) 400px`) collapsed to one column on mobile; **inspector hidden**, agent-graph SVG scales full-width, caption added ("explore on desktop"). Fixes the blank-graph + empty-inspector-bar you saw.

## portfolio.html
- Same graph fallback for the competency graph (`minmax(0,1fr) 360px` + fixed-height box → single column, inspector hidden, SVG scales via aspect-ratio).
- **Selected Work rows:** `.project-row` (`80px 1fr 320px`) and the hero (`1fr 360px`) now stack to a single full-width column on mobile. Fixes row 01 overflow **and** the center-third squeeze — the row grid couldn't wrap because the fixed 80/320px tracks always reserved their width; stacking gives every row full width and uniform reflow.

## Notes
- Approach per design note: reuse the existing SVG (no raster assets). If labels read too small on device, we swap to a committed screenshot — that's the one thing to eyeball on Safari.
- Mobile rules use `!important` (components are inline-styled).

## Test on merge (Safari)
1. index + portfolio graphs: present, scaled, captioned — not blank, no empty inspector.
2. Selected Work: every row full-width, row 01 no longer overflows.
3. No horizontal clipping of content on either page.

Then we reassess — including a spot-check that the Tier 0 overflow guard isn't hiding content on the deferred pages.