### PR TITLE
Polish (#163): headline clamp + data.js fixes

### DIFF
--- a/components/PortfolioMain.jsx
+++ b/components/PortfolioMain.jsx
@@ -35,7 +35,7 @@ const PortfolioHero = () => {
           <h1 style={{
             marginTop: 14, marginBottom: 18,
             fontFamily: 'var(--font-display)', fontWeight: 700,
-            fontSize: 76, lineHeight: 0.98, letterSpacing: '-0.025em',
+            fontSize: 'clamp(40px, 11vw, 76px)', lineHeight: 0.98, letterSpacing: '-0.025em',
             fontVariationSettings: '"opsz" 144',
             maxWidth: 760,
           }}>

--- a/data.js
+++ b/data.js
@@ -123,7 +123,7 @@ window.HISTORY = [
 
 window.ME = {
   name:     'Jeremy Montz',
-  title:    'senior product manager · operator · learning AI in public',
+  title:    'senior product manager · operator · building AI in public',
   blurb:    'I create products. Lately I run experiments. Claudemonzter is my first lab — an operator-plus-agents practice where I plug a small graph of projects into a much larger graph of models, and document what happens.',
   location: 'Portland, OR, USA',
   github:   'github.com/JeremyMontz',
@@ -154,7 +154,7 @@ window.SPEC = {
 window.NOW = [
   'Search engine optimizationa and mobile responsiveness',
   'Testing Spirit and the persona matrix',
-  'Testing Heart and Phils Journal',
+  "Testing Heart and Phil's Journal",
   'First site demo (Hi Mom!)'
 ];
 
@@ -263,9 +263,9 @@ window.PORTFOLIO = [
     excerpt: null,
   },
   {
-    id: 'Phils-Journal',
+    id: 'phils-journal',
     no: '04',
-    title: 'Phils Journal with the AI Wisdom of the Day',
+    title: "Phil's Journal with the AI Wisdom of the Day",
     blurb: 'A random quote each day from A Treasury of Traditional Wisdom, with AI commentary.',
     status: 'PROTOTYPE',
     tone: 'warn',
@@ -402,17 +402,17 @@ window.AGENT_ARTIFACTS = {
      { title: 'Speed to insight and alpha decay',             sub: 'ESSAY · 2 MIN · FUTURE',    href: '../../writing/speed-to-insight.html' }, 
   ],
   evolve:   [
-    { title: 'A Month and a Day', sub: 'INTERACTIVE · 32 DAYS · GRAPH',            href: 'writing/first-month.html' },
+    { title: 'A Month and a Day', sub: 'INTERACTIVE · 32 DAYS · GRAPH',            href: '../../writing/first-month.html' },
     { title: 'Claudemonzter - Memory',             sub: 'LAYER MAP · 5 LAYERS · 3 PLATFORMS',   href: '../../graph/memory.html' },
     { title: 'Claudemonzter - Brain',             sub: 'INBOX · RAW · WIKI',   href: '../../graph/brain.html' },
   ],
   assessor: [
-   { title: 'Adversarial validation and structured perspective expansion', sub: 'ESSAY · 2 min · Week 2',            href: 'writing/adversarial-validation.html' },
+   { title: 'Adversarial validation and structured perspective expansion', sub: 'ESSAY · 2 min · Week 2',            href: '../../writing/adversarial-validation.html' },
   ],
   phil:     [
       { title: 'Claudemonzter - Heart',             sub: 'WISDOM OF THE DAY · WITH AI COMMENTARY',   href: '../../graph/heart.html' },
-      { title: 'Phils Journal',             sub: 'WOTD · WORDCLOUD · PROTOTYPE',   href: '../../agents/phil/journal.html' },
-      { title: 'Inference economics', sub: 'ESSAY · 2 min · COST',            href: 'writing/inference-economics.html' },
+      { title: "Phil's Journal",             sub: 'WOTD · WORDCLOUD · PROTOTYPE',   href: '../../agents/phil/journal.html' },
+      { title: 'Inference economics', sub: 'ESSAY · 2 min · COST',            href: '../../writing/inference-economics.html' },
   ],
   jeremy:   [
     { title: 'Operation: Claudemonzter',    sub: 'START HERE · 8 AGENTS · THE LAB',   href: '../../about/ai.html' },

--- a/index.html
+++ b/index.html
@@ -128,7 +128,7 @@ window.PAGE_HOME = {
   graph: {
     heading: "One graph. Three projects. Seven domains.",  // plain part
     headingAccent: "And a human.",                                  // italic purple part
-    hoverLine: "Hover any node to explore the grap. Agents will surface their latest session card. Click the node to visit their page.",
+    hoverLine: "Hover any node to explore the graph. Agents will surface their latest session card. Click the node to visit their page.",
   },
 
   // ── Section 02 · now + showcase ──


### PR DESCRIPTION
Follow-ups from the review comment + your nitpicks.

**Done**
- **Headline clamp** — portfolio 76px hero -> `clamp(40px, 11vw, 76px)` (the one real open item from the comment).
- **"grap" -> "graph"** in index PAGE_HOME.
- **"Phils Journal" -> "Phil's Journal"** — 3 spots in data.js (the journal page itself already used "Phil's").
- **id `Phils-Journal` -> `phils-journal`** — verified the id is referenced nowhere else (portfolio rows key off `p.no`, cross-links use `demonstrates`), so the rename is safe.
- **ME.title** -> "building AI in public" (aligns with the existing "building Claudemonzter" hero + the 'building' competency).
- **AGENT_ARTIFACTS hrefs** -> `../../` for evolve & assessor **and phil** (inference economics had the same 404 bug — flagging since you only named two).

**Stale — no change needed**
- **`Month-two` details `[['ROLE', ], ['STARTED', ]]`**: doesn't exist anymore. Every PORTFOLIO `details` array is now a proper 2-element pair; there's no empty-detail entry.
- **`Month-two` id**: there is no PORTFOLIO id by that name (HISTORY uses `m2`). Only `Phils-Journal` broke the convention.

**Bonus bugs I noticed (not touched — your call)**
- meta1 AGENT_ARTIFACTS: "Agentic Behavioral Tuning" (sub says SPIRIT) points to `graph/hands.html`.
- meta1: "Claudemonzter - Stomach" carries Memory's descriptor (LAYER MAP · 5 LAYERS · 3 PLATFORMS).