### PR TITLE
A11y: portfolio competency graph keyboard access

### DIFF
--- a/components/CompetencyGraph.jsx
+++ b/components/CompetencyGraph.jsx
@@ -54,7 +54,7 @@ const CompetencyGraph = () => {
         border: '1px solid var(--line)', background: 'var(--bg-elev-1)', padding: 12,
         height: CG_HEIGHT, display: 'flex', alignItems: 'center', justifyContent: 'center',
       }}>
-        <svg viewBox="0 0 820 400" style={{ width: '100%', height: '100%' }}>
+        <svg viewBox="0 0 820 400" role="group" aria-label="Competency graph. Tab through nodes to see the evidence behind each." style={{ width: '100%', height: '100%' }}>
           {pos.map((p, i) => (
             <line key={'edge-' + i} x1={cx} y1={cy} x2={p[0]} y2={p[1]} strokeWidth="1"
               style={{ stroke: i === sel ? palette[i % palette.length] : 'var(--line-loud)' }} />
@@ -70,8 +70,12 @@ const CompetencyGraph = () => {
             const on = i === sel;
             const color = palette[i % palette.length];
             return (
-              <g key={c.id} style={{ cursor: 'pointer' }}
-                 onMouseEnter={() => setSel(i)} onClick={() => setSel(i)}>
+              <g key={c.id} className="graph-node" tabIndex={0} role="button"
+                 aria-label={`${c.node}${c.label ? ': ' + c.label : ''} — show evidence`}
+                 style={{ cursor: 'pointer' }}
+                 onMouseEnter={() => setSel(i)} onClick={() => setSel(i)}
+                 onFocus={() => setSel(i)}
+                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setSel(i); } }}>
                 <circle cx={pos[i][0]} cy={pos[i][1]} r={on ? 24 : 20} strokeWidth="1.5"
                   style={{ fill: on ? color : 'var(--bg-elev-2)', stroke: color }} />
                 <text x={pos[i][0]} y={pos[i][1] + 4} textAnchor="middle" fontSize="11" fontWeight="700"


### PR DESCRIPTION
Extends the #266 keyboard pattern to the **portfolio competency graph**, and reports on ai.html.

## portfolio.html — competency graph
- Nodes now focusable (`tabIndex=0`, `role=button`, `aria-label` = competency name + description).
- `onFocus` mirrors hover → selecting a node shows its evidence in the inspector via keyboard.
- Enter/Space activates; `:focus-visible` ring inherited from the global `.graph-node` rule shipped in #266. `<svg>` gets `role=group` + label.

## about/ai.html — no change needed ✅
Its hotspots are real `<a>`/`<button>`s but **deliberately** `tabIndex=-1` + `aria-hidden`, sitting over a parallel `<nav aria-label="System organs">` text index that builds a real `<a href>` for every live organ. The accessible keyboard/SR path already exists by design — adding tab stops to the overlay would just duplicate it.

## Test (desktop)
Tab through the portfolio "What It Proves" graph — each node focuses with a ring and reveals its evidence; Enter selects.

That covers the interactive graphs across the site (index + portfolio); the rest is semantic HTML.