### PR TITLE
Drop manual data.js cache-bust params (Option B)

### DIFF
--- a/data.js
+++ b/data.js
@@ -27,8 +27,10 @@
  * Files I depend on:
  *   none. This is loaded as plain JS via <script src="data.js"></script>
  *   BEFORE the JSX components. The components read these as globals.
- *   NOTE: bump the ?v= on the data.js <script> tag in each HTML page whenever
- *   you change this file, or the browser/CDN will serve a cached old copy.
+ *   CACHING: pages load this as plain `data.js` (no ?v= param). GitHub Pages
+ *   serves it with a short cache lifetime, so edits go live within minutes of a
+ *   deploy. The manual ?v= cache-bust was dropped — it had drifted across pages
+ *   (3.3/3.4/3.6) and ~30 pages never used it.
  * ========================================================================== */
 
 // ─── SITE · canonical metadata shown in nav, footer, hard stats ──────────

--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@
 
 <!-- Content data (edit me!) — loaded plain so it's the simplest possible surface.
      Shared facts (name, links) and lists (articles, portfolio, agents) live there. -->
-<script src="data.js?v=3.4"></script>
+<script src="data.js"></script>
 
 <!-- ════════════════════════════════════════════════════════════════════
      PAGE CONTENT · the words on this page — edit freely.

--- a/portfolio.html
+++ b/portfolio.html
@@ -59,7 +59,7 @@
 
 <div id="root"></div>
 
-<script src="data.js?v=3.6"></script>
+<script src="data.js"></script>
 
 <!-- PAGE_PORTFOLIO · page-specific prose for portfolio.html (the #186 PAGE_* pattern).
      Edit copy here; facts/lists live in data.js (ME, SPEC, PORTFOLIO). -->

--- a/writing.html
+++ b/writing.html
@@ -57,7 +57,7 @@
 
 <div id="root"></div>
 
-<script src="data.js?v=3.3"></script>
+<script src="data.js"></script>
 
 <script type="text/babel" src="components/Wordmark.jsx"></script>
 <script type="text/babel" src="components/Primitives.jsx"></script>


### PR DESCRIPTION
**Option B — single-source by removing the manual cache-bust.**

Whole-tree sweep found `?v=` on **only 3 pages**, all inconsistent, while ~30 pages already loaded plain `data.js`:
- index.html `?v=3.4` → `data.js`
- portfolio.html `?v=3.6` → `data.js`
- writing.html `?v=3.3` → `data.js`
- **No `?v=` on any component script** (HomeShell.jsx etc.) — confirmed, nothing else to sweep.
- Fixed the now-wrong "bump the ?v= in each HTML page" note in data.js.

Every page now loads `data.js` consistently and relies on GitHub Pages' short cache lifetime (~10 min). `SITE.version` (the displayed TopNav/footer version) is untouched. No behavior change beyond consistent caching.