### PR TITLE
Add lightweight, no-build CI (link check, data.js guard, codespell)

### DIFF
--- a/.github/scripts/check-links.mjs
+++ b/.github/scripts/check-links.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/**
+ * Internal link check (CI)
+ * ----------------------------------------------------------------------------
+ * Verifies every internal href/src in the site's HTML resolves to a real file.
+ * Encodes the two path conventions this site uses:
+ *   "/Meta1/..."   GitHub Pages project base  -> resolve against repo root
+ *   "/..."         site-absolute               -> resolve against repo root
+ *   "foo" / "../"  relative                     -> resolve against file's dir
+ *
+ * Out of scope (internal-only, deterministic, no network):
+ *   external links (http, mailto, tel, data, javascript:) and pure "#" anchors.
+ * Files whose name starts with "_" are skipped (templates/partials that carry
+ * [REPLACE] tokens by design).
+ *
+ * If the site ever moves to a custom domain, set PAGES_BASE to '/'.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, dirname, normalize, relative } from 'node:path';
+
+const ROOT = process.cwd();
+const PAGES_BASE = '/Meta1/';
+const LINK_RE = /(?:href|src)\s*=\s*["']([^"']+)["']/gi;
+const EXTERNAL = /^(https?:|mailto:|tel:|data:|javascript:|#)/i;
+
+function walk(dir, out = []) {
+  for (const e of readdirSync(dir)) {
+    if (e === '.git') continue;
+    const p = join(dir, e);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (e.endsWith('.html') && !e.startsWith('_')) out.push(p);
+  }
+  return out;
+}
+const exists = (p) => { try { statSync(p); return true; } catch { return false; } };
+
+const broken = [];
+let checked = 0;
+for (const file of walk(ROOT)) {
+  const dir = dirname(file);
+  for (const m of readFileSync(file, 'utf8').matchAll(LINK_RE)) {
+    let u = m[1].trim();
+    if (EXTERNAL.test(u)) continue;
+    u = u.split('#')[0].split('?')[0];
+    if (!u) continue;
+    let target;
+    if (u.startsWith(PAGES_BASE)) target = join(ROOT, u.slice(PAGES_BASE.length));
+    else if (u.startsWith('/'))   target = join(ROOT, u.slice(1));
+    else                          target = normalize(join(dir, u));
+    checked++;
+    if (!exists(target)) broken.push(`${relative(ROOT, file)}  ->  ${m[1]}`);
+  }
+}
+
+console.log(`internal links checked: ${checked}`);
+if (broken.length) {
+  console.error(`\nbroken internal links: ${broken.length}`);
+  for (const b of broken) console.error(`  x ${b}`);
+  process.exit(1);
+}
+console.log('all internal links resolve.');

--- a/.github/scripts/validate-data.mjs
+++ b/.github/scripts/validate-data.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * data.js integrity guard (CI)
+ * ----------------------------------------------------------------------------
+ * data.js and the graph/*-data.js files power every page on the site. A single
+ * syntax slip (stray comma, unclosed bracket) takes down all of them at once,
+ * silently, until someone opens a page. This check fails the build instead.
+ *
+ * Two assertions, both cheap:
+ *   1. PARSE  - every data file evaluates without throwing (syntax errors).
+ *   2. SHAPE  - the root data.js exposes its expected window.* sections
+ *               (catches truncation / a section deleted by accident).
+ *
+ * It deliberately does NOT police content (e.g. empty [LABEL, ] value slots) -
+ * those are authoring choices, not breakage.
+ */
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+
+const DATA_FILES = [
+  'data.js',
+  'graph/brain-data.js',
+  'graph/heart-data.js',
+  'graph/memory-data.js',
+  'graph/spirit-data.js',
+];
+
+// Core sections that must exist in root data.js. STATS / SITE_INDEX sit near
+// the end of the file, so requiring them also catches a truncated upload.
+const REQUIRED_SECTIONS = [
+  'SITE', 'ME', 'NOW', 'PORTFOLIO', 'ARTICLES',
+  'PROJECTS', 'AGENTS', 'LEVELS', 'AGENT_ARTIFACTS', 'SITE_INDEX', 'STATS',
+];
+
+const errors = [];
+const sandbox = { window: {}, document: {}, console, navigator: {} };
+const context = vm.createContext(sandbox);
+
+for (const file of DATA_FILES) {
+  let src;
+  try {
+    src = readFileSync(file, 'utf8');
+  } catch {
+    errors.push(`MISSING FILE: ${file}`);
+    continue;
+  }
+  try {
+    vm.runInContext(src, context, { filename: file });
+    console.log(`  ok   parsed ${file}`);
+  } catch (e) {
+    errors.push(`PARSE ERROR in ${file}: ${e.message}`);
+  }
+}
+
+for (const key of REQUIRED_SECTIONS) {
+  if (!(key in sandbox.window)) {
+    errors.push(`MISSING SECTION: window.${key} (expected in data.js)`);
+  }
+}
+
+if (errors.length) {
+  console.error('\ndata.js integrity check FAILED:');
+  for (const e of errors) console.error(`  x ${e}`);
+  process.exit(1);
+}
+console.log('\ndata.js integrity OK - all files parse, all sections present.');

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+# Cheapest meaningful CI for a no-build static site. Three honest checks:
+#   links    - every internal link in the HTML resolves to a real file
+#   data     - data.js (+ graph/*-data.js) parse and expose their sections
+#   spelling - codespell over content, with the lab's coined words allow-listed
+# Advisory for now (informational on PRs). Promote to a required status check
+# on the main ruleset once the tree is green.
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  links:
+    name: Internal links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: node .github/scripts/check-links.mjs
+
+  data:
+    name: data.js integrity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: node .github/scripts/validate-data.mjs
+
+  spelling:
+    name: Spellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: codespell-project/actions-codespell@v2
+        with:
+          skip: "*.png,*.jpg,*.jpeg,*.gif,*.svg,*.ico,*.woff,*.woff2,*.ttf,*.min.js,*.lock,.git,./graph/assets"
+          ignore_words_list: "claudemonzter,monzter,lectio,pura,vivekachudamani"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-# Cheapest meaningful CI for a no-build static site. Three honest checks:
+# Lightweight, no-build CI for the static site. Three honest checks:
 #   links    - every internal link in the HTML resolves to a real file
 #   data     - data.js (+ graph/*-data.js) parse and expose their sections
 #   spelling - codespell over content, with the lab's coined words allow-listed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,5 +43,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: codespell-project/actions-codespell@v2
         with:
-          skip: "*.png,*.jpg,*.jpeg,*.gif,*.svg,*.ico,*.woff,*.woff2,*.ttf,*.min.js,*.lock,.git,./graph/assets"
-          ignore_words_list: "claudemonzter,monzter,lectio,pura,vivekachudamani"
+          skip: "*.png,*.jpg,*.jpeg,*.gif,*.svg,*.ico,*.woff,*.woff2,*.ttf,*.min.js,*.lock,*.pdf,.git,./graph/assets"
+          ignore_words_list: "claudemonzter,monzter,lectio,pura,vivekachudamani,checkin,acount,wasn,couldn,te,thats"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **A multi-agent AI lab, built by one product manager — in public, from zero.**
 
+[![CI](https://github.com/JeremyMontz/Meta1/actions/workflows/ci.yml/badge.svg)](https://github.com/JeremyMontz/Meta1/actions/workflows/ci.yml)
+
 ![The Claudemonzter graph — 8 agents (1 human) across 4 projects, coordinated from one core](graph/assets/agent-graph.png)
 
 ## What this is


### PR DESCRIPTION
## What
Lightweight, no-build CI for the static site — three honest jobs plus a README badge. The lab evals its own front door.

| Job | Catches | Current run |
|---|---|---|
| **Internal links** | broken internal `href`/`src` across the 44 HTML pages | RED — 1 real bug |
| **data.js integrity** | a syntax slip or missing section in `data.js` / `graph/*-data.js` that would break every page at once | GREEN |
| **Spellcheck** | typos (codespell), domain/code tokens allow-listed | RED — 1 real typo |

## Why a custom link checker instead of lychee
The site serves under the `/Meta1/` Pages base. lychee `--offline` would report ~39 correct favicon links as false 404s and bury the one real broken link. The ~35-line `check-links.mjs` encodes the `/Meta1/` base + relative conventions and skips `_`-prefixed templates: **zero false positives.**

## Genuine defects this surfaced (left RED on purpose)
Both are site **content** fixes, out of scope for this CI-infra PR — handle in follow-ups:
1. **Broken link** — `writing/inference-economics.html` → `../agents/phil/heart.html` (link text "daily lectio"). Target doesn't exist.
2. **Typo** — `writing/first-month.html`: "so dilligently preserved" → *diligently*.

## Spellcheck tuning
First run flagged 14 false positives; all suppressed by skipping `*.pdf` (résumé OCR garbage) and allow-listing `checkin` (domain term), `acount` (a variable), split-apostrophe contractions, `te` ("Tao te ching"), and a stopword-list token. Spell job is now red **only** on genuine typos.

## Rollout
**Advisory now** — informational on PRs, does not block merges. Once the two defects above are fixed and the tree is green, promote `Internal links`, `data.js integrity`, and `Spellcheck` to **required** status checks on the `main` ruleset so they gate every future PR.

## Notes
- Pushed by the `meta1-monzter` bot via the GitHub API (Workflows permission added 2026-06-16).
- If the site moves to a custom domain, set `PAGES_BASE = '/'` in `check-links.mjs`.
