### PR TITLE
Fix codespell config — scope false positives, stop allow-listing real words

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,8 @@
+# Spellcheck config for the Claudemonzter site — read automatically by codespell.
+# Allow-list = coined proper nouns ONLY. Real-word false positives are suppressed
+# by case/context-specific regex so a genuine typo is never globally hidden.
+[codespell]
+skip = *.png,*.jpg,*.jpeg,*.gif,*.svg,*.ico,*.woff,*.woff2,*.ttf,*.min.js,*.lock,*.pdf,.git,./graph/assets
+ignore-words-list = claudemonzter,monzter,lectio,pura,vivekachudamani,checkin
+# aCount=code identifier | "tao te"=Tao Te Ching | "then thats"=stopword token | word&rsquo;word=HTML-entity contractions
+ignore-regex = aCount|tao te|then thats|[A-Za-z]+&rsquo;[A-Za-z]*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # All spell config (skip / ignore-words / ignore-regex) lives in
+      # .codespellrc at the repo root, which codespell reads automatically.
       - uses: codespell-project/actions-codespell@v2
-        with:
-          skip: "*.png,*.jpg,*.jpeg,*.gif,*.svg,*.ico,*.woff,*.woff2,*.ttf,*.min.js,*.lock,*.pdf,.git,./graph/assets"
-          ignore_words_list: "claudemonzter,monzter,lectio,pura,vivekachudamani,checkin,acount,wasn,couldn,te,thats"


### PR DESCRIPTION
## Why
The first spell-tuning (PR #269) put real, error-shaped words — `acount`, `wasn`, `couldn`, `te`, `thats` — into the **global** `ignore_words_list`. That silences the spellchecker for those words *everywhere*, which defeats the tool. None of the five were actual typos, but the fix was the wrong shape.

## What changed
All codespell config moves into a commented **`.codespellrc`** at the repo root:
- **`ignore-words-list`** — coined proper nouns only: `claudemonzter, monzter, lectio, pura, vivekachudamani, checkin`.
- **`ignore-regex`** — case/context-specific, so no real word is blinded:
  - `aCount` — a code identifier (count of 'A' boundaries), not 'account'.
  - `tao te` — "Tao Te Ching" in a scripture regex.
  - `then thats` — a token in the journal stopword list.
  - `[A-Za-z]+&rsquo;[A-Za-z]*` — `wasn&rsquo;t` / `couldn&rsquo;t`; the content was correct (proper typographic apostrophe as an HTML entity), codespell's tokenizer was splitting it.

`ci.yml`'s spell job now just runs the action, which reads `.codespellrc`.

## Proof
Against the full tree: **clean (exit 0)**. A planted `acount` / `sentance` typo in prose **still fails** — the dictionary stays sharp for genuine errors.

## Note
The one judgment call is `checkin` — a coined technical term (sheet tabs, POST types) used like `login`. If you'd rather it not be allow-listed, say so and I'll scope it by regex instead.