### PR TITLE
#211 — client-side PIN gate on public form pages

### DIFF
--- a/agents/house/house-entry.html
+++ b/agents/house/house-entry.html
@@ -438,6 +438,19 @@
   </div>
 
 <script>
+// ── #211 client-side PIN gate (casual-submission deterrent; not a security boundary — see #227) ──
+var PIN_HASH = "9f79d46789159fde2ce018beb8417f80b6856be31d861688b59a2db120ae7e2b";
+async function pinSha(s){var b=await crypto.subtle.digest("SHA-256",new TextEncoder().encode(s));return Array.from(new Uint8Array(b)).map(function(x){return x.toString(16).padStart(2,"0");}).join("");}
+async function pinGateOk(){
+  if(window.__pinUnlocked) return true;
+  while(true){
+    var v=window.prompt("Enter 4-digit PIN to submit:");
+    if(v===null) return false;
+    if(await pinSha(v.trim())===PIN_HASH){window.__pinUnlocked=true;return true;}
+    window.alert("Incorrect PIN. Try again.");
+  }
+}
+
 // ── Config ──
 const GAS_URL = 'https://script.google.com/macros/s/AKfycbwRMUIRMQmDcGezmMJ8w-vgtrmS2skTvS5el4gXTsMB9SZpSyfgKf5sv41W7SouWfv50Q/exec';
 
@@ -637,6 +650,7 @@ function buildTaskDropdown() {
 
 // ── Submit task ──
 async function submitTask() {
+  if (!(await pinGateOk())) return;
   const btn = document.getElementById('taskSubmit');
   const msg = document.getElementById('statusMsg');
 
@@ -718,6 +732,7 @@ async function submitTask() {
 
 // ── Submit expense ──
 async function submitExpense() {
+  if (!(await pinGateOk())) return;
   const btn = document.getElementById('expenseSubmit');
   const msg = document.getElementById('statusMsg2');
 

--- a/checkin.html
+++ b/checkin.html
@@ -216,10 +216,24 @@ button[type="submit"]:disabled { opacity: 0.4; cursor: not-allowed; }
 </div>
 
 <script>
+// ── #211 client-side PIN gate (casual-submission deterrent; not a security boundary — see #227) ──
+var PIN_HASH = "9f79d46789159fde2ce018beb8417f80b6856be31d861688b59a2db120ae7e2b";
+async function pinSha(s){var b=await crypto.subtle.digest("SHA-256",new TextEncoder().encode(s));return Array.from(new Uint8Array(b)).map(function(x){return x.toString(16).padStart(2,"0");}).join("");}
+async function pinGateOk(){
+  if(window.__pinUnlocked) return true;
+  while(true){
+    var v=window.prompt("Enter 4-digit PIN to submit:");
+    if(v===null) return false;
+    if(await pinSha(v.trim())===PIN_HASH){window.__pinUnlocked=true;return true;}
+    window.alert("Incorrect PIN. Try again.");
+  }
+}
+
 // GAS Web App webhook — targets HumanCheckin tab
 var GAS_URL = "https://script.google.com/macros/s/AKfycbxIOramPHpz7lypIO8ivFkN9-g9Tre_izkhetZjZRYA_Lnjtmno6uNRvGvbONkJLxOn/exec";
 
 async function submitCheckin() {
+  if (!(await pinGateOk())) return;
   var btn = document.getElementById("submitBtn");
   var msg = document.getElementById("statusMsg");
 

--- a/graph/spirit-app.jsx
+++ b/graph/spirit-app.jsx
@@ -38,6 +38,19 @@ async function gasPost(payload) {
   });
 }
 
+// ── #211 client-side PIN gate (casual-submission deterrent; not a security boundary — see #227) ──
+const PIN_HASH = '9f79d46789159fde2ce018beb8417f80b6856be31d861688b59a2db120ae7e2b';
+async function pinSha(s){const b=await crypto.subtle.digest("SHA-256",new TextEncoder().encode(s));return Array.from(new Uint8Array(b)).map(x=>x.toString(16).padStart(2,"0")).join("");}
+async function pinGateOk(){
+  if(window.__pinUnlocked) return true;
+  while(true){
+    const v=window.prompt('Enter 4-digit PIN to submit:');
+    if(v===null) return false;
+    if(await pinSha(v.trim())===PIN_HASH){window.__pinUnlocked=true;return true;}
+    window.alert('Incorrect PIN. Try again.');
+  }
+}
+
 // ─── Header ────────────────────────────────────────────────────────────────
 const SpiritHeader = ({ hyde, crazy, dirtyCount, onCommit, onDiscard, committing,
                        rev, lastSync, customCount, totalCells }) => (
@@ -524,6 +537,7 @@ const App = () => {
   // ── Commit dials to GAS ──
   const commit = async () => {
     if (dirtyCount === 0) return;
+    if (!(await pinGateOk())) return;
     setCommitting(true);
 
     // Build edits array for GAS
@@ -570,6 +584,7 @@ const App = () => {
 
   // ── Save agent metadata (signature + boundaries) to GAS ──
   const saveAgent = async (signature, boundaries) => {
+    if (!(await pinGateOk())) return;
     const agentId = editingAgentId;
     setSavingAgent(true);
 


### PR DESCRIPTION
Closes #211.

Client-side 4-digit PIN gate on the three public write-forms. On first submit attempt the page prompts for a PIN, hashes it with SHA-256, and compares against a baked-in constant; a correct PIN unlocks submissions for the rest of the page session, a wrong one re-prompts.

**Pages gated**
- `checkin.html` — `submitCheckin()`
- `agents/house/house-entry.html` — `submitTask()` + `submitExpense()`
- `graph/spirit-app.jsx` — `commit()` + `saveAgent()`

**One shared PIN/hash** across all three (SHA-256 constant `9f79…e7e2b`; cleartext PIN not in repo).

**What this is / isn't.** Deterrent against casual/bot submissions that never read source — that case is fully blocked. It is **not** a security boundary: a 4-digit PIN has only 10k values, so anyone reading the hash in public source can brute-force it in milliseconds. The real control is server-side write auth at the GAS endpoint — tracked in #227, intentionally out of scope here.

**Untouched:** GAS endpoint URLs and the skill callers (quick-start/full-start/lectio open-checkin POSTs are unaffected — gate is purely client-side).

Notes: SHA-256 over SHA-1 (no deprecated primitive); `crypto.subtle` requires a secure context — fine on GitHub Pages (https). Verified: 0318 passes / wrong fails, and spirit-app.jsx transpiles clean under @babel/preset-react.