### PR TITLE
Fix first-month: restore sticky graph (overflow-x clip, not hidden)

### DIFF
--- a/writing/first-month.html
+++ b/writing/first-month.html
@@ -30,7 +30,7 @@
     background: var(--bg);
     color: var(--fg);
     font-family: var(--font-sans);
-    overflow-x: hidden;
+    overflow-x: clip; /* clip (not hidden) so body stays non-scroll-container -> .graph-col sticky works */
   }
   body::before {
     content: "";


### PR DESCRIPTION
**Symptom:** the node graph no longer stays pinned while chapters scroll; it scrolls off the top ('long page mode'). Only visible on the chapter where it starts.

**Root cause** (not #275): `body { overflow-x: hidden }` from the #163 mobile pass forces computed `overflow-y: auto`, making `<body>` a scroll container, which defeats `position: sticky` on `.graph-col`. The boot bug (#275) was masking this -- a graph that never renders can't be seen scrolling away.

**Fix:** `overflow-x: hidden` -> `overflow-x: clip` on `body`. `clip` still suppresses horizontal scroll (mobile guard intact) but does not establish a scroll container, so sticky is restored.

**Verified live (throttle-immune layout test):** `.graph-col` top stays at 80px through the full scroll with `clip` (was -1920 / -4920 with `hidden`).

Single declaration changed. Note: the same body guard likely exists site-wide; a follow-up sweep of other pages with sticky elements is planned.