### PR TITLE
first-month mobile: undim chapters + keep graph opaque above them

### DIFF
--- a/writing/first-month.html
+++ b/writing/first-month.html
@@ -307,8 +307,11 @@
 
   @media (max-width: 900px) {
     main.case { grid-template-columns: 1fr; gap: 20px; padding: 68px 16px 0; }
-    .graph-col { position: sticky; top: 60px; height: 50vh; }
+    /* graph stays opaque and above the chapters that scroll underneath it */
+    .graph-col { position: sticky; top: 60px; height: 50vh; z-index: 2; background: var(--bg); }
     .chapter, .case-hero, .end-card { max-width: 100%; }
+    /* single-column reading: chapters read full-strength (no desktop active-chapter dim) */
+    .chapter { opacity: 1; }
     .chapters { padding: 40px 8px 60vh; gap: 30vh; }
   }
 


### PR DESCRIPTION
Mobile polish for the first-month scrollytelling page (desktop unchanged).

**1. Undim chapters on mobile.** The active-chapter dim (`.chapter` opacity 0.35 -> 1 on `.is-current`) is a desktop affordance for the graph-beside-text layout. In single-column mobile it just flickers as the center-band observer toggles `is-current` (with dead-zones between chapters). Set `.chapter { opacity: 1 }` in the mobile media query so chapters read full-strength.

**2. Keep the graph opaque and above the chapters.** Chapters scroll underneath the sticky graph; add `z-index: 2` + an explicit opaque `background` to `.graph-col` on mobile so nothing shows through at any edge. (Measured: the graph already occludes at center; this hardens the edges/precaution for the undimmed state.)

Both changes are scoped to `@media (max-width: 900px)`. One file.