### PR TITLE
Sweep: overflow-x hidden -> clip on remaining guard pages

### DIFF
--- a/agents/phil/journal.html
+++ b/agents/phil/journal.html
@@ -31,7 +31,7 @@
     color: var(--fg);
     margin: 0;
     min-height: 100vh;
-    overflow-x: hidden;
+    overflow-x: clip;
   }
   body { font-family: var(--font-sans); }
   a { color: inherit; text-decoration: none; }

--- a/design-system/index.html
+++ b/design-system/index.html
@@ -16,7 +16,7 @@
     color: var(--fg);
     font-family: var(--font-sans);
     min-height: 100vh;
-    overflow-x: hidden;
+    overflow-x: clip;
   }
   /* Subtle animated violet wash behind everything */
   body::before {

--- a/graph/_template.html
+++ b/graph/_template.html
@@ -27,7 +27,7 @@
 
 <style>
   html, body { background: var(--bg); color: var(--fg); margin: 0; min-height: 100vh; }
-  body { padding: 0; margin: 0; overflow-x: hidden; font-family: var(--font-sans); }
+  body { padding: 0; margin: 0; overflow-x: clip; font-family: var(--font-sans); }
   a { color: inherit; text-decoration: none; }
 
   /* Graph sub-nav — keep consistent with dashboard.html, heart.html, memory.html */

--- a/graph/brain.html
+++ b/graph/brain.html
@@ -31,7 +31,7 @@
     color: var(--fg);
     margin: 0;
     min-height: 100vh;
-    overflow-x: hidden;
+    overflow-x: clip;
   }
   body { font-family: var(--font-sans); }
   a { color: inherit; text-decoration: none; }

--- a/graph/faces.html
+++ b/graph/faces.html
@@ -26,7 +26,7 @@
 <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" crossorigin="anonymous"></script>
 
 <style>
-  html, body { background: var(--bg); color: var(--fg); margin: 0; min-height: 100vh; overflow-x: hidden; }
+  html, body { background: var(--bg); color: var(--fg); margin: 0; min-height: 100vh; overflow-x: clip; }
   body { font-family: var(--font-sans); }
   a { color: inherit; text-decoration: none; }
   .page { width: 100%; max-width: 1280px; margin: 0 auto; }

--- a/graph/heart.html
+++ b/graph/heart.html
@@ -31,7 +31,7 @@
     color: var(--fg);
     margin: 0;
     min-height: 100vh;
-    overflow-x: hidden;
+    overflow-x: clip;
   }
   body {
     font-family: var(--font-sans);

--- a/graph/memory.html
+++ b/graph/memory.html
@@ -24,7 +24,7 @@
 
 <style>
   html, body { background: var(--bg); color: var(--fg); margin: 0; min-height: 100vh; }
-  body { padding: 0; margin: 0; overflow-x: hidden; font-family: var(--font-sans); }
+  body { padding: 0; margin: 0; overflow-x: clip; font-family: var(--font-sans); }
   a { color: inherit; text-decoration: none; }
 
   /* Graph sub-nav — matches dashboard.html */

--- a/graph/spirit.html
+++ b/graph/spirit.html
@@ -24,7 +24,7 @@
 
 <style>
   html, body { background: var(--bg); color: var(--fg); margin: 0; min-height: 100vh; }
-  body { padding: 0; margin: 0; overflow-x: hidden; font-family: var(--font-sans); }
+  body { padding: 0; margin: 0; overflow-x: clip; font-family: var(--font-sans); }
   a { color: inherit; text-decoration: none; }
 
   /* Graph sub-nav — matches dashboard.html */


### PR DESCRIPTION
**Hygiene sweep following the first-month sticky fix (#276).**

`body { overflow-x: hidden }` forces computed `overflow-y: auto`, making `<body>` a scroll container, which defeats `position: sticky` on descendants. This converts the remaining 8 pages carrying that guard to `overflow-x: clip` — identical horizontal-overflow suppression, no scroll-container side effect.

**None of these 8 are currently broken** (no sticky element on them today). The point is prevention: `graph/_template.html` is the scaffold for new graph pages, so it propagates the landmine — and graph pages are exactly where sticky subnavs tend to get added. Eradicating the pattern stops it recurring by copy-paste.

Files: `agents/phil/journal.html`, `design-system/index.html`, `graph/_template.html`, `graph/brain.html`, `graph/faces.html`, `graph/heart.html`, `graph/memory.html`, `graph/spirit.html`.

One-line change each (`hidden` → `clip`), single commit.