### PR TITLE
Contract test harness (#294)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,11 @@
 name: CI
-# Lightweight, no-build CI for the static site. Three honest checks:
-#   links    - every internal link in the HTML resolves to a real file
-#   data     - data.js (+ graph/*-data.js) parse and expose their sections
-#   spelling - codespell over content, with the lab's coined words allow-listed
-# Advisory for now (informational on PRs). Promote to a required status check
-# on the main ruleset once the tree is green.
+# Lightweight, no-build CI for the static site. Four honest checks:
+#   links     - every internal link in the HTML resolves to a real file
+#   data      - data.js (+ graph/*-data.js) parse and expose their sections
+#   spelling  - codespell over content, with the lab's coined words allow-listed
+#   contracts - bond/Tests/*.test.mjs site-contract regression bench (one check, whole suite)
+# links / data / spelling are REQUIRED on the main ruleset (strict). Add the
+# "Contract tests" check to the required list once this lands green.
 on:
   pull_request:
     branches: [main]
@@ -44,3 +45,13 @@ jobs:
       # All spell config (skip / ignore-words / ignore-regex) lives in
       # .codespellrc at the repo root, which codespell reads automatically.
       - uses: codespell-project/actions-codespell@v2
+
+  contracts:
+    name: Contract tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: node bond/Tests/run.mjs

--- a/bond/Tests/_assert.mjs
+++ b/bond/Tests/_assert.mjs
@@ -1,0 +1,18 @@
+// bond/Tests/_assert.mjs
+// Tiny shared reporter for contract TCs — uniform failure format, no framework.
+// Not a TC (no ".test." infix, and "_"-prefixed) so the runner never runs it.
+export function makeReport(name) {
+  const fails = [];
+  return {
+    check: (cond, msg) => { if (!cond) fails.push(msg); },
+    done: (summary) => {
+      console.log(summary);
+      if (fails.length) {
+        console.error(`\n${name}: ${fails.length} failure(s)`);
+        for (const f of fails) console.error(`  x ${f}`);
+        process.exit(1);
+      }
+      console.log(`${name}: ok`);
+    },
+  };
+}

--- a/bond/Tests/run.mjs
+++ b/bond/Tests/run.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/**
+ * Contract test runner (CI) — bond/Tests/run.mjs
+ * ----------------------------------------------------------------------------
+ * Discovers every *.test.mjs under bond/Tests/, runs each in an ISOLATED child
+ * process (so one TC's throw or process.exit cannot abort the batch), captures
+ * exit code + output, prints an aggregate report, and exits non-zero if any TC
+ * failed OR if the bench is empty (an empty bench is a misconfiguration, not a
+ * pass). Each TC is a standalone zero-dep node script that exits 1 on failure,
+ * 0 on pass — same convention as .github/scripts/check-links.mjs. Files whose
+ * basename starts with "_" are helpers, not TCs, and are skipped.
+ */
+import { readdirSync, statSync } from 'node:fs';
+import { join, relative, basename } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const ROOT = process.cwd();
+const TEST_DIR = join(ROOT, 'bond', 'Tests');
+const isTest = (n) => n.endsWith('.test.mjs') && !basename(n).startsWith('_');
+
+function walk(dir, out = []) {
+  for (const e of readdirSync(dir)) {
+    const p = join(dir, e);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (isTest(e)) out.push(p);
+  }
+  return out;
+}
+
+console.log('── Contract tests ─────────────────');
+
+let tests = [];
+try { tests = walk(TEST_DIR); }
+catch (err) { console.error(`cannot read ${relative(ROOT, TEST_DIR)} — ${err.message}`); process.exit(1); }
+
+if (tests.length === 0) {
+  console.error('no *.test.mjs found in bond/Tests — empty bench is a misconfiguration.');
+  process.exit(1);
+}
+
+let failed = 0;
+for (const file of tests.sort()) {
+  const t0 = Date.now();
+  const res = spawnSync('node', [file], { cwd: ROOT, encoding: 'utf8' });
+  const ms = Date.now() - t0;
+  const ok = res.status === 0 && !res.error;
+  if (!ok) failed++;
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${basename(file)}  (${ms}ms)`);
+  if (!ok) {
+    const out = `${res.stdout || ''}${res.stderr || ''}`.trimEnd();
+    if (res.error) console.log(`        spawn error: ${res.error.message}`);
+    for (const line of out.split('\n')) if (line) console.log(`        ${line}`);
+  }
+}
+
+console.log('─'.repeat(48));
+console.log(`Contract tests: ${tests.length - failed} passed, ${failed} failed`);
+process.exit(failed ? 1 : 0);

--- a/bond/Tests/smoke.test.mjs
+++ b/bond/Tests/smoke.test.mjs
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+/**
+ * Smoke test — proves the runner discovers, executes, and reports a TC.
+ * Always passes; a permanent canary that the harness itself is alive.
+ * Not a real contract test (TC1 = #298).
+ */
+import { makeReport } from './_assert.mjs';
+const r = makeReport('smoke');
+r.check(1 + 1 === 2, 'arithmetic is broken (the universe has bigger problems)');
+r.done('smoke: harness alive, 1 assertion checked');


### PR DESCRIPTION
Builds the contract test harness — work item #8 of the autonomous-dev pipeline (#288). Spec: `projects/meta1/meta1/design/test-harness-spec.md`.

**What's here**
- `bond/Tests/run.mjs` — runner: recursive discovery of `*.test.mjs`, child-process isolation per TC, aggregate report, exits non-zero on any failure **or** an empty bench.
- `bond/Tests/_assert.mjs` — tiny shared reporter (uniform failure format, zero deps).
- `bond/Tests/smoke.test.mjs` — always-pass canary proving the harness is alive (not a real contract test — TC1 is #298).
- `.github/workflows/ci.yml` — new `Contract tests` job runs the whole suite; advisory comment refreshed.

**One check, whole suite.** Adding TC1/TC2/... drops files into `bond/Tests/`; the required-check count stays at one. Standard practice, no per-test sprawl.

**Verified locally before push:** green path exit 0 · empty bench exit 1 (fail-loud) · planted failure exit 1 with isolation intact (**teeth proven**).

**Jeremy's hand-step after merge:** add `Contract tests` to the `main` ruleset's required-check list (gate-ownership stays human).

Closes #294.