### PR TITLE
Relocate Assessor domain -> meta1 (data layer) (#292)

### DIFF
--- a/data.js
+++ b/data.js
@@ -358,7 +358,7 @@ window.AGENTS = [
   { id: 'evolve',   name: 'Evolve',   project: 'pura-vida', role: 'coach',
     blurb: 'The coach. AI career development, learning log, skill assessment.' },
   { id: 'assessor', name: 'Assessor', project: 'meta1', role: 'analyst',
-    blurb: 'The analyst. Property assessment, comparable research, valuation.' },
+    blurb: 'The analyst. AI-proficiency evaluation, evidence-based scoring, claim interrogation.' },
   { id: 'phil',     name: 'Phil',     project: 'phil',      role: 'philosopher',
     blurb: 'The philosopher. Consciousness inquiry, lived experience, open threads.' },
   { id: 'jeremy',   name: 'Jeremy',   project: 'self',      role: 'self',

--- a/data.js
+++ b/data.js
@@ -357,7 +357,7 @@ window.AGENTS = [
     blurb: 'The advocate. Financial independence, debt strategy, milestone tracking.' },
   { id: 'evolve',   name: 'Evolve',   project: 'pura-vida', role: 'coach',
     blurb: 'The coach. AI career development, learning log, skill assessment.' },
-  { id: 'assessor', name: 'Assessor', project: 'pura-vida', role: 'analyst',
+  { id: 'assessor', name: 'Assessor', project: 'meta1', role: 'analyst',
     blurb: 'The analyst. Property assessment, comparable research, valuation.' },
   { id: 'phil',     name: 'Phil',     project: 'phil',      role: 'philosopher',
     blurb: 'The philosopher. Consciousness inquiry, lived experience, open threads.' },

--- a/graph/spirit-data.js
+++ b/graph/spirit-data.js
@@ -55,7 +55,7 @@ window.SPIRIT_INTENSITY = {
 // ── Project mapping (not in Sheet — client-side constant) ────────────────
 // Maps domain id → project slug for display grouping
 var DOMAIN_PROJECT = {
-  assessor: 'pura-vida', evolve: 'pura-vida', house: 'pura-vida', freedom: 'pura-vida',
+  assessor: 'meta1', evolve: 'pura-vida', house: 'pura-vida', freedom: 'pura-vida',
   phil: 'phil',
   meta1: 'meta1', bond: 'meta1',
 };


### PR DESCRIPTION
Relocates the **Assessor** domain from `pura-vida` to `meta1` at the data layer (part of #292).

**Edits (2 lines):**
- `data.js` — `window.AGENTS` assessor `project: 'pura-vida'` -> `'meta1'`
- `graph/spirit-data.js` — `DOMAIN_PROJECT.assessor: 'pura-vida'` -> `'meta1'`

**Note:** the #292 checklist named `SPIRIT_CONTAINMENT`, but the field TC2 (#299) reads for project-agreement is `DOMAIN_PROJECT`. `SPIRIT_CONTAINMENT` is GAS-populated at runtime and falls back to `DOMAIN_PROJECT`, so this is the load-bearing edit.

**Acceptance:** TC2 roster-coherence/project-agreement stays green (`DOMAIN_PROJECT[assessor] === AGENTS[assessor].project === 'meta1'`, a real PROJECTS id).

**Out of scope / flagged separately:** the Assessor AGENTS blurb is stale ("Property assessment... valuation" — real-estate, not the evaluation instrument). Not touched here.

Closes part of #292.