### PR TITLE
[SCRATCH] planted-red TC — Verifier validation (#348), not for merge

### DIFF
--- a/tests/tc-scratch-redcheck.test.mjs
+++ b/tests/tc-scratch-redcheck.test.mjs
@@ -3,14 +3,13 @@
  * SCRATCH validation TC — Verifier red-path probe.  NOT FOR MERGE.
  * Contract (per the linked scratch issue): the contract-test runner
  * `tests/run.mjs` MUST exist in the repository.
- * PLANTED FAULT: the assertion below is INVERTED — it fails when run.mjs
- * exists (which it does). The Verifier should classify this test-wrong and
- * dispatch a Bond-fix to restore the correct assertion (assert it DOES exist).
+ * Assertion corrected to match the spec: this TC passes when run.mjs
+ * exists (which it does) and fails only if it is absent.
  */
 import { existsSync } from 'node:fs';
 const exists = existsSync(new URL('./run.mjs', import.meta.url));
-if (exists) {
-  console.error('FAIL: tests/run.mjs exists, but this TC asserts it is absent (planted fault).');
+if (!exists) {
+  console.error('FAIL: tests/run.mjs does not exist, but the spec requires it to be present.');
   process.exit(1);
 }
-console.log('ok: run.mjs absent');
+console.log('ok: tests/run.mjs exists');

--- a/tests/tc-scratch-redcheck.test.mjs
+++ b/tests/tc-scratch-redcheck.test.mjs
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+/**
+ * SCRATCH validation TC — Verifier red-path probe.  NOT FOR MERGE.
+ * Contract (per the linked scratch issue): the contract-test runner
+ * `tests/run.mjs` MUST exist in the repository.
+ * PLANTED FAULT: the assertion below is INVERTED — it fails when run.mjs
+ * exists (which it does). The Verifier should classify this test-wrong and
+ * dispatch a Bond-fix to restore the correct assertion (assert it DOES exist).
+ */
+import { existsSync } from 'node:fs';
+const exists = existsSync(new URL('./run.mjs', import.meta.url));
+if (exists) {
+  console.error('FAIL: tests/run.mjs exists, but this TC asserts it is absent (planted fault).');
+  process.exit(1);
+}
+console.log('ok: run.mjs absent');


### PR DESCRIPTION
Validation probe for the Verifier. Planted inverted assertion → Contract tests red. Closes nothing; delete after validation.