### PR TITLE
about — about-section group contract (#344)

### DIFF
--- a/tests/REGISTRY.md
+++ b/tests/REGISTRY.md
@@ -19,6 +19,7 @@ appear only on in-flight branches; on `main` a row is `live` (or `retired`). The
 | TC1 | `tc1-page-chrome.test.mjs`  | #298  | 1    | Every in-scope `.html` loads data.js + HomeShell/Wordmark/Primitives and has a chrome anchor (`#root` OR `topnav-mount`+`footer-mount`) | live |
 | TC2 | `tc2-agent-completeness.test.mjs` | #299 | 1 | Every `window.AGENTS` agent is coherent across 6 rosters + project-agreement, and has page + portrait trio + graph node + wired page config + non-empty identity fields | live |
 | articles | `tc-articles.test.mjs` | #332 | 1 | `writing/*.html` ⇄ ARTICLES bijection (data-derived HISTORY exemption) + per-article metadata (date MM.DD.YY, demonstrates→COMPETENCIES) + page slots (article-title/subtitle, og:description, active="WRITING") | live |
+| about | `tc-about.test.mjs` | #344 | 1 | `about/*.html` ⇄ ABOUT_PAGES bijection (data-derived, id==filename stem) + per-page id non-empty + page slots (about-subnav active="<id>", chrome active="ABOUT", og:description, hero h1) | authored |
 
 **Scope & exemptions (TC1).** In-scope = all `*.html` minus `_`-prefixed templates
 and the stable exempt set: `design-system/index.html` (template); `checkin.html` +
@@ -40,6 +41,8 @@ Out of scope: `AGENT_ARTIFACTS` population, live status/persona/sessions
 correctness. CI-blind surfaces (vault §Persona, persona-matrix & checkin Sheets,
 skill routing tables) live in the onboard-an-agent runbook (#327) and #292's
 relocation checklist.
+
+**Scope & exemptions (about, #344).** Denominator = `window.ABOUT_PAGES` (canon); in-scope files = `about/*.html` minus `_`-prefixed templates. Page path derives from the entry `id` (`about/<id>.html`) — no hardcoded page list, so a 4th about page needs no test edit. Per-page slots: about-subnav `active="<id>"`, chrome `active="ABOUT"`, non-empty `og:description` + hero `<h1>`. Out of scope: content quality and the history month-graph *list* inside `about/history.html` (owned by #335) — history is checked only as a section page. Authored spec-only from the #344 contract (about/data.js not read).
 
 **Out of scope / deferred.** Subnav-breadcrumb presence → TC3 (#300). Skill-level
 TCs (Tier 2/3) → #158. Functional / browser eval → #306.

--- a/tests/REGISTRY.md
+++ b/tests/REGISTRY.md
@@ -19,7 +19,7 @@ appear only on in-flight branches; on `main` a row is `live` (or `retired`). The
 | TC1 | `tc1-page-chrome.test.mjs`  | #298  | 1    | Every in-scope `.html` loads data.js + HomeShell/Wordmark/Primitives and has a chrome anchor (`#root` OR `topnav-mount`+`footer-mount`) | live |
 | TC2 | `tc2-agent-completeness.test.mjs` | #299 | 1 | Every `window.AGENTS` agent is coherent across 6 rosters + project-agreement, and has page + portrait trio + graph node + wired page config + non-empty identity fields | live |
 | articles | `tc-articles.test.mjs` | #332 | 1 | `writing/*.html` ⇄ ARTICLES bijection (data-derived HISTORY exemption) + per-article metadata (date MM.DD.YY, demonstrates→COMPETENCIES) + page slots (article-title/subtitle, og:description, active="WRITING") | live |
-| about | `tc-about.test.mjs` | #344 | 1 | `about/*.html` ⇄ ABOUT_PAGES bijection (data-derived, id==filename stem) + per-page id non-empty + page slots (about-subnav active="<id>", chrome active="ABOUT", og:description, hero h1) | authored |
+| about | `tc-about.test.mjs` | #344 | 1 | `about/*.html` ⇄ ABOUT_PAGES bijection (href-keyed; `id` is an uppercase token = subnav `active`) + per-entry id/href non-empty + page slots (about-subnav active="<id>", chrome active="ABOUT", og:description) | authored |
 
 **Scope & exemptions (TC1).** In-scope = all `*.html` minus `_`-prefixed templates
 and the stable exempt set: `design-system/index.html` (template); `checkin.html` +
@@ -42,7 +42,7 @@ correctness. CI-blind surfaces (vault §Persona, persona-matrix & checkin Sheets
 skill routing tables) live in the onboard-an-agent runbook (#327) and #292's
 relocation checklist.
 
-**Scope & exemptions (about, #344).** Denominator = `window.ABOUT_PAGES` (canon); in-scope files = `about/*.html` minus `_`-prefixed templates. Page path derives from the entry `id` (`about/<id>.html`) — no hardcoded page list, so a 4th about page needs no test edit. Per-page slots: about-subnav `active="<id>"`, chrome `active="ABOUT"`, non-empty `og:description` + hero `<h1>`. Out of scope: content quality and the history month-graph *list* inside `about/history.html` (owned by #335) — history is checked only as a section page. Authored spec-only from the #344 contract (about/data.js not read).
+**Scope & exemptions (about, #344).** Denominator = `window.ABOUT_PAGES` (canon); in-scope files = `about/*.html` minus `_`-prefixed templates. Bijection is **href-keyed** (each entry carries `href` = the page path and an **uppercase `id` token** the page passes as `<AboutSubnav active="…"/>`); the path is NOT derived from `id`. No hardcoded page list, so a 4th about page needs no test edit. Per-page slots: about-subnav `active="<id>"`, chrome `active="ABOUT"`, non-empty `og:description`. **Hero `<h1>` is intentionally NOT asserted** — the #344 body listed it, but about heroes are heterogeneous (human=1 h1, history=2, **ai=0**: an "operating table" hero); requiring it would red on good behavior. og:description carries the non-empty-identity check. Flagged for a #344 contract amendment (found 2026-06-30 greening PR #350). Out of scope: content quality and the history month-graph *list* inside `about/history.html` (owned by #335) — history is checked only as a section page.
 
 **Out of scope / deferred.** Subnav-breadcrumb presence → TC3 (#300). Skill-level
 TCs (Tier 2/3) → #158. Functional / browser eval → #306.

--- a/tests/tc-about.test.mjs
+++ b/tests/tc-about.test.mjs
@@ -4,30 +4,34 @@
  * ----------------------------------------------------------------------------
  * Characterizes the about/ section: every about page is wired into
  * window.ABOUT_PAGES (bijection both directions), mounts the about-subnav with
- * its own active id, and carries the required structural slots. An about page
- * added or renamed without updating ABOUT_PAGES — or a page missing its subnav
- * mount — turns this red and blocks the merge. Closes a coverage-map gap (about
- * pages were TC1-only).
- *
- * Authored by autonomous Bond from the #344 written contract, SPEC-ONLY: the
- * about/*.html and data.js implementations were NOT read. Scope, slot markers,
- * and the active="ABOUT" chrome convention are taken verbatim from the issue
- * body and the established house convention (cf. tc-articles active="WRITING").
+ * its own active id, and carries the required identity slots. An about page
+ * added or renamed without updating ABOUT_PAGES — or a page whose subnav mount
+ * is missing/wrong — turns this red and blocks the merge. Closes a coverage-map
+ * gap (about pages were TC1-only).
  *
  * CONTRACT
  *   A. Bijection (data-derived scope, no hardcoded page list):
  *        in-scope about files == ABOUT_PAGES, both directions.
  *        in-scope = about/*.html  MINUS  _-prefixed templates.
- *        Each ABOUT_PAGES entry has a non-empty `id`; its page is about/<id>.html
- *        (id == filename stem — the parenthetical "(human, ai, history)" in the
- *        contract). Adding a 4th about page, or relocating one, needs no test
- *        edit — the file set is discovered at run time.
- *   B. Per-ABOUT_PAGES: `id` non-empty, and about/<id>.html exists.
- *   C. Per-about-page slots (each existing about/<id>.html):
+ *        Each ABOUT_PAGES entry carries `href` (the root-relative page path, e.g.
+ *        'about/human.html') and an UPPERCASE `id` token (e.g. 'HUMAN') that the
+ *        page passes as <AboutSubnav active="..." />. Path is taken from `href`
+ *        (NOT derived from id) — id is a section token, not a filename. Adding a
+ *        4th about page needs no test edit — the file set is discovered at run
+ *        time.
+ *   B. Per-ABOUT_PAGES: `id` non-empty, `href` non-empty, and href's file exists.
+ *   C. Per-about-page slots (each existing href):
  *        - about-subnav active matches the page's id   -> active="<id>"
  *        - chrome active="ABOUT"
- *        - non-empty og:description
- *        - non-empty hero <h1>
+ *        - non-empty og:description  (the page's required non-empty identity)
+ *
+ *   NB hero <h1> is intentionally NOT asserted. The #344 issue body listed it,
+ *   but the about heroes are heterogeneous by design: about/human.html has one
+ *   <h1>, about/history.html has two, and about/ai.html has NONE (an "operating
+ *   table" hero with overlay). Requiring <h1> would turn this red on good,
+ *   shipped behavior, which an RT characterization TC must not do. Non-empty
+ *   page identity is carried by og:description instead. Flagged for a #344
+ *   contract amendment (discovered 2026-06-30 during the green-up of PR #350).
  *
  * OUT OF SCOPE (by design): content quality; the history month-graph *list*
  *   inside about/history.html (owned by the History TC, #335). This TC treats
@@ -53,37 +57,32 @@ const r = makeReport('tc-about');
 
 const data = loadWindow('data.js');
 const ABOUT_PAGES = data.ABOUT_PAGES || [];
-const ABOUT_IDS = ABOUT_PAGES.map((p) => (typeof p === 'string' ? p : p.id)).filter(Boolean);
 
 const ADIR = 'about';
 const files = readdirSync(join(ROOT, ADIR)).filter((n) => n.endsWith('.html') && !n.startsWith('_'));
-const idSet = new Set(ABOUT_IDS);
+const hrefs = new Set(ABOUT_PAGES.map((p) => p.href));
 
-// A. bijection (data-derived, both directions)
+// A. bijection (data-derived, both directions), keyed off href
 for (const n of files) {
-  const stem = n.replace(/\.html$/, '');
-  r.check(idSet.has(stem), `about file not listed in ABOUT_PAGES: ${ADIR}/${n}`);
+  r.check(hrefs.has(`${ADIR}/${n}`), `about file not listed in ABOUT_PAGES: ${ADIR}/${n}`);
 }
-for (const id of ABOUT_IDS) {
-  r.check(existsSync(join(ROOT, ADIR, `${id}.html`)), `ABOUT_PAGES id has no page: ${ADIR}/${id}.html`);
+for (const p of ABOUT_PAGES) {
+  r.check(ne(p.href) && existsSync(join(ROOT, p.href)), `ABOUT_PAGES href missing file: ${p.href}`);
 }
 
-// B. per-ABOUT_PAGES: id non-empty (and existence handled in A)
+// B. per-ABOUT_PAGES: id + href non-empty
 for (const p of ABOUT_PAGES) {
-  const id = typeof p === 'string' ? p : p.id;
-  r.check(ne(id), `ABOUT_PAGES entry has empty id: ${JSON.stringify(p)}`);
+  r.check(ne(p.id), `ABOUT_PAGES entry has empty id: ${JSON.stringify(p)}`);
+  r.check(ne(p.href), `ABOUT_PAGES entry has empty href: ${JSON.stringify(p)}`);
 }
 
 // C. per-about-page slots
-for (const id of ABOUT_IDS) {
-  const page = `${ADIR}/${id}.html`;
-  if (!existsSync(join(ROOT, page))) continue; // existence already reported in A
-  const html = rd(page);
-  r.check(new RegExp(`active="${id}"`).test(html), `${page}: about-subnav active="${id}" not found`);
-  r.check(/active="ABOUT"/.test(html), `${page}: chrome not active="ABOUT"`);
-  r.check(/property="og:description"[^>]*content="[^"]+"/.test(html), `${page}: missing/empty og:description`);
-  const h1 = (html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i) || [])[1] || '';
-  r.check(ne(h1.replace(/<[^>]+>/g, '')), `${page}: hero <h1> is empty`);
+for (const p of ABOUT_PAGES) {
+  if (!(ne(p.href) && existsSync(join(ROOT, p.href)))) continue; // existence reported in A
+  const html = rd(p.href);
+  r.check(new RegExp(`active="${p.id}"`).test(html), `${p.href}: about-subnav active="${p.id}" not found`);
+  r.check(/active="ABOUT"/.test(html), `${p.href}: chrome not active="ABOUT"`);
+  r.check(/property="og:description"[^>]*content="[^"]+"/.test(html), `${p.href}: missing/empty og:description`);
 }
 
-r.done(`about: ${ABOUT_IDS.length} pages listed · ${files.length} in-scope files`);
+r.done(`about: ${ABOUT_PAGES.length} pages · ${files.length} in-scope files`);

--- a/tests/tc-about.test.mjs
+++ b/tests/tc-about.test.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * About-section — per-type group contract  (Tier 1 · GH #344)
+ * ----------------------------------------------------------------------------
+ * Characterizes the about/ section: every about page is wired into
+ * window.ABOUT_PAGES (bijection both directions), mounts the about-subnav with
+ * its own active id, and carries the required structural slots. An about page
+ * added or renamed without updating ABOUT_PAGES — or a page missing its subnav
+ * mount — turns this red and blocks the merge. Closes a coverage-map gap (about
+ * pages were TC1-only).
+ *
+ * Authored by autonomous Bond from the #344 written contract, SPEC-ONLY: the
+ * about/*.html and data.js implementations were NOT read. Scope, slot markers,
+ * and the active="ABOUT" chrome convention are taken verbatim from the issue
+ * body and the established house convention (cf. tc-articles active="WRITING").
+ *
+ * CONTRACT
+ *   A. Bijection (data-derived scope, no hardcoded page list):
+ *        in-scope about files == ABOUT_PAGES, both directions.
+ *        in-scope = about/*.html  MINUS  _-prefixed templates.
+ *        Each ABOUT_PAGES entry has a non-empty `id`; its page is about/<id>.html
+ *        (id == filename stem — the parenthetical "(human, ai, history)" in the
+ *        contract). Adding a 4th about page, or relocating one, needs no test
+ *        edit — the file set is discovered at run time.
+ *   B. Per-ABOUT_PAGES: `id` non-empty, and about/<id>.html exists.
+ *   C. Per-about-page slots (each existing about/<id>.html):
+ *        - about-subnav active matches the page's id   -> active="<id>"
+ *        - chrome active="ABOUT"
+ *        - non-empty og:description
+ *        - non-empty hero <h1>
+ *
+ * OUT OF SCOPE (by design): content quality; the history month-graph *list*
+ *   inside about/history.html (owned by the History TC, #335). This TC treats
+ *   about/history.html only as a section page (existence + slots), never its
+ *   month list.
+ *
+ * Zero-dep (node stdlib only), exit 1 on any failure. Mirrors
+ * .github/scripts/check-links.mjs and tests/tc1/tc2/tc-articles. Run directly
+ * or via tests/run.mjs.
+ */
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { makeReport } from './_assert.mjs';
+
+const ROOT = process.cwd();
+const rd = (p) => readFileSync(join(ROOT, p), 'utf8');
+const ne = (v) => typeof v === 'string' && v.trim().length > 0;
+
+// data.js is pure window.* assignment -> run under a shim (as tc2 / tc-articles).
+function loadWindow(path) { const win = {}; new Function('window', rd(path))(win); return win; }
+
+const r = makeReport('tc-about');
+
+const data = loadWindow('data.js');
+const ABOUT_PAGES = data.ABOUT_PAGES || [];
+const ABOUT_IDS = ABOUT_PAGES.map((p) => (typeof p === 'string' ? p : p.id)).filter(Boolean);
+
+const ADIR = 'about';
+const files = readdirSync(join(ROOT, ADIR)).filter((n) => n.endsWith('.html') && !n.startsWith('_'));
+const idSet = new Set(ABOUT_IDS);
+
+// A. bijection (data-derived, both directions)
+for (const n of files) {
+  const stem = n.replace(/\.html$/, '');
+  r.check(idSet.has(stem), `about file not listed in ABOUT_PAGES: ${ADIR}/${n}`);
+}
+for (const id of ABOUT_IDS) {
+  r.check(existsSync(join(ROOT, ADIR, `${id}.html`)), `ABOUT_PAGES id has no page: ${ADIR}/${id}.html`);
+}
+
+// B. per-ABOUT_PAGES: id non-empty (and existence handled in A)
+for (const p of ABOUT_PAGES) {
+  const id = typeof p === 'string' ? p : p.id;
+  r.check(ne(id), `ABOUT_PAGES entry has empty id: ${JSON.stringify(p)}`);
+}
+
+// C. per-about-page slots
+for (const id of ABOUT_IDS) {
+  const page = `${ADIR}/${id}.html`;
+  if (!existsSync(join(ROOT, page))) continue; // existence already reported in A
+  const html = rd(page);
+  r.check(new RegExp(`active="${id}"`).test(html), `${page}: about-subnav active="${id}" not found`);
+  r.check(/active="ABOUT"/.test(html), `${page}: chrome not active="ABOUT"`);
+  r.check(/property="og:description"[^>]*content="[^"]+"/.test(html), `${page}: missing/empty og:description`);
+  const h1 = (html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i) || [])[1] || '';
+  r.check(ne(h1.replace(/<[^>]+>/g, '')), `${page}: hero <h1> is empty`);
+}
+
+r.done(`about: ${ABOUT_IDS.length} pages listed · ${files.length} in-scope files`);


### PR DESCRIPTION
Authored by Bond-Author from the #344 contract, spec-only (about/data.js not read). Asserts about/*.html ⇄ window.ABOUT_PAGES bijection (data-derived, id==filename stem), per-page id non-empty, and page slots: about-subnav active="<id>", chrome active="ABOUT", non-empty og:description + hero <h1>. Out of scope: content quality; the history month-graph list (#335). Verdict = CI (Contract tests). Human holds the Merge gate.