### PR TITLE
live-display — cross-cutting read-path (#336)

### DIFF
--- a/tests/REGISTRY.md
+++ b/tests/REGISTRY.md
@@ -21,6 +21,7 @@ appear only on in-flight branches; on `main` a row is `live` (or `retired`). The
 | TC3 | `tc3-organ-structural.test.mjs` | #300 | 1 | Every `window.ORGANS` entry (body.html excepted) wires its GraphSubnav, sets `active="<id>"` matching its ORGANS id (case-insensitive), and loads `graph/<stem>-data.js` when one exists; existence ceded to #334, checked-count guard prevents vacuity | authored |
 | articles | `tc-articles.test.mjs` | #332 | 1 | `writing/*.html` ⇄ ARTICLES bijection (data-derived HISTORY exemption) + per-article metadata (date MM.DD.YY, demonstrates→COMPETENCIES) + page slots (article-title/subtitle, og:description, active="WRITING") | live |
 | about | `tc-about.test.mjs` | #344 | 1 | `about/*.html` ⇄ ABOUT_PAGES bijection (href-keyed; `id` is an uppercase token = subnav `active`) + per-entry id/href non-empty + page slots (about-subnav active="<id>", chrome active="ABOUT", og:description) | authored |
+| live-display | `tc-live-display.test.mjs` | #336 | 1 | Every discovered live surface either loads the shared `agent-card.js` (delegates source+status+fallback) OR rolls its own with all four inline (data source csvUrl/gviz/GAS + fetch + `#dataStatus` + NO-DATA/.catch). Denominator self-discovered (declared-list is a stronger future variant); vacuity-guarded | authored |
 
 **Scope & exemptions (TC1).** In-scope = all `*.html` minus `_`-prefixed templates
 and the stable exempt set: `design-system/index.html` (template); `checkin.html` +

--- a/tests/tc-live-display.test.mjs
+++ b/tests/tc-live-display.test.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * Live-display wiring — cross-cutting read-path  (Tier 1 · GH #336)
+ * ----------------------------------------------------------------------------
+ * One contract, many consumers: every page that declares a live region must wire
+ * the shared fetch→render path. The teeth: a fetch/parse/render regression that
+ * silently blanks every live surface at once. Authored from the #336 written
+ * spec, spec-only (page SOURCE scanned; implementation never inspected).
+ *
+ * DENOMINATOR — the spec names a "declared list" (faces, heart, spirit, agent
+ * pages, dashboard, house-budget/entry/timeline). Enumerating those exact paths
+ * is not derivable spec-only (and "agent pages" is dynamic), so membership is
+ * DISCOVERED: a page is a live surface if its source declares a live region —
+ * it references a live data source (Sheet csvUrl()/gviz/GAS webhook) OR loads the
+ * shared component OR carries a #dataStatus element.
+ *   KNOWN BOUNDARY: a page that drops ALL of those markers at once escapes the
+ *   denominator (can't be caught by discovery). The canonical declared-list form
+ *   is a stronger future variant — it needs the explicit path list from a human.
+ *   Flagged for a #336 contract amendment.
+ *
+ * CONTRACT (per discovered live page):
+ *   Either it DELEGATES the whole path to the shared component (loads
+ *   components/agent-card.js) — which carries source+status+fallback — OR it
+ *   ROLLS ITS OWN, in which case all four must be present inline:
+ *     1. a live data source (csvUrl()/gviz URL OR a GAS /exec webhook URL)
+ *     2. a fetch/parse
+ *     3. a #dataStatus element
+ *     4. a NO-DATA / .catch empty-state fallback
+ *
+ * OUT OF SCOPE: that the live VALUES are correct (Tier 4 / runtime).
+ *
+ * Zero-dep (node stdlib only), exit 1 on any failure. Mirrors tc1's file walk.
+ * Run via tests/run.mjs.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { makeReport } from './_assert.mjs';
+
+const ROOT = process.cwd();
+
+function walk(dir, out = []) {
+  for (const e of readdirSync(dir)) {
+    if (e === '.git' || e === 'node_modules') continue;
+    const p = join(dir, e);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (e.endsWith('.html') && !e.startsWith('_')) out.push(p);
+  }
+  return out;
+}
+
+const hasDataSource = (h) =>
+  /csvUrl\s*\(/i.test(h) || /gviz/i.test(h) ||
+  /docs\.google\.com\/spreadsheets/i.test(h) ||
+  /script\.google\.com\/macros/i.test(h) || /\/exec\b/.test(h);
+const loadsShared = (h) => /agent-card\.js/i.test(h);
+const hasStatus   = (h) => /id\s*=\s*["']dataStatus["']/i.test(h) || /data-status/i.test(h);
+const hasFetch    = (h) => /fetch\s*\(/i.test(h);
+const hasFallback = (h) => /\.catch\s*\(/i.test(h) || /no[-_ ]?data/i.test(h);
+
+const r = makeReport('tc-live-display');
+
+let live = 0, delegated = 0, rollOwn = 0;
+for (const file of walk(ROOT)) {
+  const rel = relative(ROOT, file).split('\\').join('/');
+  const html = readFileSync(file, 'utf8');
+
+  const declaresLive = hasDataSource(html) || loadsShared(html) || hasStatus(html);
+  if (!declaresLive) continue;
+  live++;
+
+  if (loadsShared(html)) { delegated++; continue; } // shared component carries the path
+
+  // roll-your-own: all four must be present inline
+  rollOwn++;
+  r.check(hasDataSource(html), `${rel}: live region, no shared component, and no inline data source (csvUrl/gviz/GAS)`);
+  r.check(hasFetch(html),      `${rel}: live region, rolls its own, but no fetch/parse`);
+  r.check(hasStatus(html),     `${rel}: live region, rolls its own, but no #dataStatus element`);
+  r.check(hasFallback(html),   `${rel}: live region, rolls its own, but no NO-DATA/.catch fallback`);
+}
+
+// vacuity guard — if discovery finds no live surfaces, the marker set regressed
+r.check(live > 0, 'no live surfaces discovered — the live-region marker set regressed, or the shared path was renamed');
+
+r.done(`live-display: ${live} live surfaces (${delegated} delegate to shared component, ${rollOwn} roll their own)`);


### PR DESCRIPTION
Authored by Bond-Author from the #336 contract, spec-only. Cross-cutting Tier 1: every discovered live surface either loads the shared agent-card.js (which carries source+status+fallback) OR rolls its own with all four inline (live data source csvUrl/gviz/GAS + fetch + #dataStatus + NO-DATA/.catch fallback). NOTE: the spec's 'declared list' denominator can't be enumerated spec-only (agent pages are dynamic), so membership is self-discovered via live-region markers — a page that drops ALL markers escapes discovery; the declared-list form is a stronger future variant needing the explicit path list. Flagged for a #336 contract amendment. Live values correctness is out of scope (Tier 4). Vacuity-guarded. Verdict = CI (Contract tests). Human holds the Merge gate.